### PR TITLE
fix(web): remove redundant View Details floating button on mobile

### DIFF
--- a/apps/web/src/routes/wallpapers.$wallpaperId.tsx
+++ b/apps/web/src/routes/wallpapers.$wallpaperId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useParams } from '@tanstack/react-router';
-import { ChevronDown, ChevronUp, Download, PanelRight, Share } from 'lucide-react';
+import { ChevronDown, Download, PanelRight, Share } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -266,16 +266,6 @@ export function WallpaperDetailPage() {
           </div>
         </div>
       </div>
-
-      {/* Mobile peek indicator */}
-      {isMobile && !isPanelOpen && (
-        <div className="fixed bottom-4 left-1/2 z-40 -translate-x-1/2">
-          <Button variant="secondary" onClick={() => setIsPanelOpen(true)} className="shadow-lg">
-            <ChevronUp className="mr-2 h-4 w-4" />
-            View Details
-          </Button>
-        </div>
-      )}
 
       {/* Metadata panel */}
       <Sheet open={isPanelOpen} onOpenChange={setIsPanelOpen}>


### PR DESCRIPTION
## Summary
- Removes the floating "View Details" button that appeared on mobile when the details panel was closed, which overlapped with the bottom action bar on small screens
- Removes the unused `ChevronUp` import from lucide-react
- The header `PanelRight` toggle button already provides the same functionality, making the floating button redundant

Closes #80