### PR TITLE
feat(web,upload): add stop uploading feature

### DIFF
--- a/apps/web/src/components/ui/progress.tsx
+++ b/apps/web/src/components/ui/progress.tsx
@@ -8,8 +8,11 @@ import { cn } from '@/lib/utils';
 function Progress({
   className,
   value,
+  variant = 'default',
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  variant?: 'default' | 'stopped';
+}) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -21,7 +24,11 @@ function Progress({
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary size-full flex-1 transition-all"
+        data-variant={variant}
+        className={cn(
+          'size-full flex-1 transition-all',
+          variant === 'stopped' ? 'bg-amber-500' : 'bg-primary'
+        )}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/apps/web/src/components/upload/upload-action-buttons.tsx
+++ b/apps/web/src/components/upload/upload-action-buttons.tsx
@@ -1,4 +1,4 @@
-import { Play, RefreshCw, Square, Trash2 } from 'lucide-react';
+import { Check, Play, RefreshCw, Square, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 interface UploadActionButtonsProps {

--- a/apps/web/src/components/upload/upload-action-buttons.tsx
+++ b/apps/web/src/components/upload/upload-action-buttons.tsx
@@ -1,0 +1,67 @@
+import { Play, RefreshCw, Square, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface UploadActionButtonsProps {
+  isRunning: boolean;
+  isPaused: boolean;
+  isStopped: boolean;
+  hasFailures: boolean;
+  isComplete: boolean;
+  onStopQueue: () => void;
+  onResumeQueue: () => void;
+  onClearAll: () => void;
+  onRetryFailed: () => void;
+  onClearCompleted: () => void;
+}
+
+export function UploadActionButtons({
+  isRunning,
+  isPaused,
+  isStopped,
+  hasFailures,
+  isComplete,
+  onStopQueue,
+  onResumeQueue,
+  onClearAll,
+  onRetryFailed,
+  onClearCompleted,
+}: UploadActionButtonsProps) {
+  const showStopButton = isRunning || isPaused;
+  const showResumeButton = isStopped;
+  const showClearAllButton = isStopped || (!isRunning && !isPaused);
+
+  return (
+    <div className="flex gap-2">
+      {hasFailures && (
+        <Button variant="outline" onClick={onRetryFailed} disabled={isRunning} className="flex-1">
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Retry failed
+        </Button>
+      )}
+      {showStopButton && (
+        <Button variant="ghost" onClick={onStopQueue} className="flex-1">
+          <Square className="mr-2 h-4 w-4" />
+          Stop uploading
+        </Button>
+      )}
+      {showResumeButton && (
+        <Button variant="outline" onClick={onResumeQueue} className="flex-1">
+          <Play className="mr-2 h-4 w-4" />
+          Resume uploading
+        </Button>
+      )}
+      {showClearAllButton && !showStopButton && (
+        <Button variant="ghost" onClick={onClearAll}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          Clear all
+        </Button>
+      )}
+      {isComplete && !isStopped && (
+        <Button variant="outline" onClick={onClearCompleted} className="flex-1">
+          <Check className="mr-2 h-4 w-4" />
+          Clear completed
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/upload/upload-queue-toast-manager.tsx
+++ b/apps/web/src/components/upload/upload-queue-toast-manager.tsx
@@ -6,7 +6,16 @@ import { useUploadQueue } from '@/contexts/upload-queue-context';
 const AUTO_DISMISS_DELAY = 5000; // 5 seconds
 
 export function UploadQueueToastManager() {
-  const { state, counts, progress, clearCompleted, retryFailed, cancelAll } = useUploadQueue();
+  const {
+    state,
+    counts,
+    progress,
+    clearCompleted,
+    retryFailed,
+    cancelAll,
+    stopQueue,
+    resumeQueue,
+  } = useUploadQueue();
   const router = useRouter();
   const [isVisible, setIsVisible] = useState(false);
   const autoDismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -70,7 +79,10 @@ export function UploadQueueToastManager() {
         counts={counts}
         progress={progress}
         isPaused={state.isPaused}
+        isStopped={state.isStopped}
         pausedUntil={state.pausedUntil}
+        onStopQueue={stopQueue}
+        onResumeQueue={resumeQueue}
         onRetryFailed={retryFailed}
         onClearCompleted={handleDismiss}
         onNavigateToUpload={handleNavigateToUpload}

--- a/apps/web/src/components/upload/upload-queue-toast.tsx
+++ b/apps/web/src/components/upload/upload-queue-toast.tsx
@@ -140,6 +140,7 @@ export function UploadQueueToast({
       {/* Progress bar */}
       <Progress
         value={progress}
+        variant={isStopped ? 'stopped' : 'default'}
         className="h-2 mb-3"
         aria-valuenow={progress}
         aria-valuemin={0}

--- a/apps/web/src/components/upload/upload-queue-toast.tsx
+++ b/apps/web/src/components/upload/upload-queue-toast.tsx
@@ -5,7 +5,9 @@ import {
   ChevronUp,
   Copy,
   Loader2,
+  Play,
   RefreshCw,
+  Square,
   X,
 } from 'lucide-react';
 import { useState } from 'react';
@@ -27,7 +29,10 @@ export interface UploadQueueToastProps {
   };
   progress: number;
   isPaused: boolean;
+  isStopped?: boolean;
   pausedUntil: number | null;
+  onStopQueue?: () => void;
+  onResumeQueue?: () => void;
   onRetryFailed: () => void;
   onClearCompleted: () => void;
   onNavigateToUpload: () => void;
@@ -55,7 +60,10 @@ export function UploadQueueToast({
   counts,
   progress,
   isPaused,
+  isStopped = false,
   pausedUntil,
+  onStopQueue,
+  onResumeQueue,
   onRetryFailed,
   onClearCompleted,
   onNavigateToUpload,
@@ -64,13 +72,14 @@ export function UploadQueueToast({
   const timeRemaining = useCountdown(pausedUntil);
 
   const isUploading = counts.uploading > 0 || counts.pending > 0;
-  const isComplete = !isUploading && !isPaused;
+  const isComplete = !isUploading && !isPaused && !isStopped;
   const hasFailures = counts.failed > 0;
   const completedCount = counts.success + counts.failed + counts.duplicate;
 
-  // Determine header text
   let headerText = '';
-  if (isPaused && timeRemaining) {
+  if (isStopped) {
+    headerText = 'Stopped';
+  } else if (isPaused && timeRemaining) {
     headerText = `Paused (resuming in ${timeRemaining})`;
   } else if (isPaused) {
     headerText = 'Paused';
@@ -79,6 +88,9 @@ export function UploadQueueToast({
   } else {
     headerText = `Uploading ${completedCount}/${counts.total} files`;
   }
+
+  const showStopButton = !isStopped && (isUploading || isPaused);
+  const showResumeButton = isStopped;
 
   const handleToastClick = (e: React.MouseEvent) => {
     // Don't navigate if clicking on buttons
@@ -177,6 +189,36 @@ export function UploadQueueToast({
 
       {/* Action buttons */}
       <div className="flex gap-2">
+        {showStopButton && (
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="stop-queue-button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onStopQueue?.();
+            }}
+            className="flex-1"
+          >
+            <Square className="h-3 w-3 mr-1" />
+            Stop
+          </Button>
+        )}
+        {showResumeButton && (
+          <Button
+            variant="outline"
+            size="sm"
+            data-testid="resume-queue-button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onResumeQueue?.();
+            }}
+            className="flex-1"
+          >
+            <Play className="h-3 w-3 mr-1" />
+            Resume
+          </Button>
+        )}
         {hasFailures && (
           <Button
             variant="outline"

--- a/apps/web/src/components/upload/upload-queue-toast.tsx
+++ b/apps/web/src/components/upload/upload-queue-toast.tsx
@@ -8,10 +8,11 @@ import {
   RefreshCw,
   X,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
 import type { QueuedFile } from '@/contexts/upload-queue-context';
+import { useCountdown } from '@/hooks/useCountdown';
 import { cn } from '@/lib/utils';
 
 export interface UploadQueueToastProps {
@@ -49,16 +50,6 @@ function getStatusIcon(status: QueuedFile['status']) {
   }
 }
 
-function formatTimeRemaining(ms: number): string {
-  const seconds = Math.max(0, Math.ceil(ms / 1000));
-  if (seconds >= 60) {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${minutes}m ${remainingSeconds}s`;
-  }
-  return `${seconds}s`;
-}
-
 export function UploadQueueToast({
   files,
   counts,
@@ -70,34 +61,12 @@ export function UploadQueueToast({
   onNavigateToUpload,
 }: UploadQueueToastProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [timeRemaining, setTimeRemaining] = useState<string | null>(null);
+  const timeRemaining = useCountdown(pausedUntil);
 
   const isUploading = counts.uploading > 0 || counts.pending > 0;
   const isComplete = !isUploading && !isPaused;
   const hasFailures = counts.failed > 0;
   const completedCount = counts.success + counts.failed + counts.duplicate;
-
-  // Update countdown timer
-  useEffect(() => {
-    if (!pausedUntil) {
-      setTimeRemaining(null);
-      return;
-    }
-
-    const updateRemaining = () => {
-      const remaining = pausedUntil - Date.now();
-      if (remaining <= 0) {
-        setTimeRemaining(null);
-      } else {
-        setTimeRemaining(formatTimeRemaining(remaining));
-      }
-    };
-
-    updateRemaining();
-    const interval = setInterval(updateRemaining, 1000);
-
-    return () => clearInterval(interval);
-  }, [pausedUntil]);
 
   // Determine header text
   let headerText = '';

--- a/apps/web/src/contexts/upload-queue-context.tsx
+++ b/apps/web/src/contexts/upload-queue-context.tsx
@@ -55,6 +55,7 @@ export interface UploadQueueState {
   files: QueuedFile[];
   isProcessing: boolean;
   isPaused: boolean;
+  isStopped: boolean;
   pausedUntil: number | null;
 }
 
@@ -66,7 +67,8 @@ export type UploadQueueAction =
   | { type: 'UPLOAD_FAILED'; payload: { fileId: string; error: UploadError } }
   | { type: 'UPLOAD_DUPLICATE'; payload: { fileId: string; response: UploadResponse } }
   | { type: 'PAUSE_QUEUE'; payload: { pausedUntil: number } }
-  | { type: 'RESUME_QUEUE' }
+  | { type: 'RESUME_QUEUE'; payload?: { now?: number } }
+  | { type: 'STOP_QUEUE' }
   | { type: 'CLEAR_COMPLETED' }
   | { type: 'RETRY_FAILED' }
   | { type: 'CANCEL_ALL' }
@@ -82,6 +84,7 @@ const initialState: UploadQueueState = {
   files: [],
   isProcessing: false,
   isPaused: false,
+  isStopped: false,
   pausedUntil: null,
 };
 
@@ -122,32 +125,44 @@ export function uploadQueueReducer(
 
     case 'UPLOAD_SUCCESS': {
       const { fileId, response } = action.payload;
-      return {
-        ...state,
-        files: state.files.map((f) =>
-          f.id === fileId ? { ...f, status: 'success' as const, response } : f
-        ),
-      };
+      const updatedFiles = state.files.map((f) =>
+        f.id === fileId ? { ...f, status: 'success' as const, response } : f
+      );
+      if (
+        state.isStopped &&
+        !updatedFiles.some((f) => f.status === 'pending' || f.status === 'uploading')
+      ) {
+        return { ...initialState };
+      }
+      return { ...state, files: updatedFiles };
     }
 
     case 'UPLOAD_FAILED': {
       const { fileId, error } = action.payload;
-      return {
-        ...state,
-        files: state.files.map((f) =>
-          f.id === fileId ? { ...f, status: 'failed' as const, error } : f
-        ),
-      };
+      const updatedFiles = state.files.map((f) =>
+        f.id === fileId ? { ...f, status: 'failed' as const, error } : f
+      );
+      if (
+        state.isStopped &&
+        !updatedFiles.some((f) => f.status === 'pending' || f.status === 'uploading')
+      ) {
+        return { ...initialState };
+      }
+      return { ...state, files: updatedFiles };
     }
 
     case 'UPLOAD_DUPLICATE': {
       const { fileId, response } = action.payload;
-      return {
-        ...state,
-        files: state.files.map((f) =>
-          f.id === fileId ? { ...f, status: 'duplicate' as const, response } : f
-        ),
-      };
+      const updatedFiles = state.files.map((f) =>
+        f.id === fileId ? { ...f, status: 'duplicate' as const, response } : f
+      );
+      if (
+        state.isStopped &&
+        !updatedFiles.some((f) => f.status === 'pending' || f.status === 'uploading')
+      ) {
+        return { ...initialState };
+      }
+      return { ...state, files: updatedFiles };
     }
 
     case 'PAUSE_QUEUE': {
@@ -159,7 +174,32 @@ export function uploadQueueReducer(
       };
     }
 
+    case 'STOP_QUEUE': {
+      return {
+        ...state,
+        isStopped: true,
+        isPaused: false,
+      };
+    }
+
     case 'RESUME_QUEUE': {
+      if (state.isStopped) {
+        const now = action.payload?.now ?? Date.now();
+        const insideRateLimit = state.pausedUntil !== null && state.pausedUntil > now;
+        if (insideRateLimit) {
+          return {
+            ...state,
+            isStopped: false,
+            isPaused: true,
+          };
+        }
+        return {
+          ...state,
+          isStopped: false,
+          isPaused: false,
+          pausedUntil: null,
+        };
+      }
       return {
         ...state,
         isPaused: false,
@@ -209,6 +249,8 @@ interface UploadQueueContextValue {
   clearCompleted: () => void;
   retryFailed: () => void;
   cancelAll: () => void;
+  stopQueue: () => void;
+  resumeQueue: () => void;
   // Computed values
   counts: {
     total: number;
@@ -278,10 +320,30 @@ export function UploadQueueProvider({ children }: UploadQueueProviderProps) {
     }
   }, []);
 
+  const stopQueue = useCallback(() => {
+    dispatch({ type: 'STOP_QUEUE' });
+    if (resumeTimeoutRef.current) {
+      clearTimeout(resumeTimeoutRef.current);
+      resumeTimeoutRef.current = null;
+    }
+  }, []);
+
+  const resumeQueue = useCallback(() => {
+    const now = Date.now();
+    dispatch({ type: 'RESUME_QUEUE', payload: { now } });
+    if (state.pausedUntil && state.pausedUntil > now) {
+      const remainingMs = state.pausedUntil - now;
+      resumeTimeoutRef.current = setTimeout(() => {
+        dispatch({ type: 'RESUME_QUEUE', payload: { now: Date.now() } });
+        dispatch({ type: 'RETRY_FAILED' });
+      }, remainingMs);
+    }
+  }, [state.pausedUntil]);
+
   // Process the next pending file
   const processNextFile = useCallback(async () => {
-    // Don't process if paused
-    if (state.isPaused) return;
+    // Don't process if paused or stopped
+    if (state.isPaused || state.isStopped) return;
 
     // Find the next pending file
     const nextFile = state.files.find((f) => f.status === 'pending');
@@ -345,18 +407,18 @@ export function UploadQueueProvider({ children }: UploadQueueProviderProps) {
         },
       });
     }
-  }, [state.files, state.isPaused]);
+  }, [state.files, state.isPaused, state.isStopped]);
 
   // Auto-process pending files
   useEffect(() => {
     const hasPending = state.files.some((f) => f.status === 'pending');
     const hasUploading = state.files.some((f) => f.status === 'uploading');
 
-    // Start processing if we have pending files and not currently uploading
-    if (hasPending && !hasUploading && !state.isPaused) {
+    // Start processing if we have pending files and not currently uploading and not stopped
+    if (hasPending && !hasUploading && !state.isPaused && !state.isStopped) {
       processNextFile();
     }
-  }, [state.files, state.isPaused, processNextFile]);
+  }, [state.files, state.isPaused, state.isStopped, processNextFile]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -373,6 +435,8 @@ export function UploadQueueProvider({ children }: UploadQueueProviderProps) {
     clearCompleted,
     retryFailed,
     cancelAll,
+    stopQueue,
+    resumeQueue,
     counts,
     progress,
   };

--- a/apps/web/src/hooks/useCountdown.ts
+++ b/apps/web/src/hooks/useCountdown.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { formatTimeRemaining } from '@/lib/utils/upload-queue';
+
+export function useCountdown(pausedUntil: number | null): string | null {
+  const [timeRemaining, setTimeRemaining] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!pausedUntil) {
+      setTimeRemaining(null);
+      return;
+    }
+
+    const updateRemaining = () => {
+      const remaining = pausedUntil - Date.now();
+      if (remaining <= 0) {
+        setTimeRemaining(null);
+      } else {
+        setTimeRemaining(formatTimeRemaining(remaining));
+      }
+    };
+
+    updateRemaining();
+    const interval = setInterval(updateRemaining, 1000);
+
+    return () => clearInterval(interval);
+  }, [pausedUntil]);
+
+  return timeRemaining;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -77,6 +77,7 @@
 
 @theme inline {
     --font-sans: 'Noto Sans Variable', sans-serif;
+    --animate-stripe: stripe 1s linear infinite;
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -128,3 +129,4 @@
     @apply font-sans;
     }
 }
+

--- a/apps/web/src/lib/utils/upload-queue.ts
+++ b/apps/web/src/lib/utils/upload-queue.ts
@@ -1,0 +1,43 @@
+export function formatTimeRemaining(ms: number): string {
+  const seconds = Math.max(0, Math.ceil(ms / 1000));
+  if (seconds >= 60) {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+export interface QueueStatusTextParams {
+  isStopped: boolean;
+  isPaused: boolean;
+  isUploading: boolean;
+  isComplete: boolean;
+  hasFiles: boolean;
+  completedCount: number;
+  totalCount: number;
+  timeRemaining: string | null;
+}
+
+export function getQueueStatusText(params: QueueStatusTextParams): string {
+  const {
+    isStopped,
+    isPaused,
+    isUploading,
+    isComplete,
+    hasFiles,
+    completedCount,
+    totalCount,
+    timeRemaining,
+  } = params;
+
+  if (isStopped) return 'Stopped';
+  if (isPaused) {
+    if (timeRemaining) return `Paused (resuming in ${timeRemaining})`;
+    return 'Paused (rate limited)';
+  }
+  if (isUploading) return `Uploading ${completedCount}/${totalCount}...`;
+  if (isComplete) return 'Upload complete';
+  if (hasFiles) return 'Ready to upload';
+  return '';
+}

--- a/apps/web/src/routes/upload.tsx
+++ b/apps/web/src/routes/upload.tsx
@@ -7,6 +7,8 @@ import { UploadDropZone } from '@/components/upload/upload-drop-zone';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { MAX_FILES_PER_BATCH, useUploadQueue } from '@/contexts/upload-queue-context';
+import { useCountdown } from '@/hooks/useCountdown';
+import { getQueueStatusText } from '@/lib/utils/upload-queue';
 import { cn } from '@/lib/utils';
 
 export const Route = createFileRoute('/upload')({
@@ -55,6 +57,18 @@ function UploadPage() {
   const isRunning = isUploading && !state.isPaused && !state.isStopped;
   const isComplete = hasFiles && !isUploading && !state.isPaused && !state.isStopped;
   const hasFailures = counts.failed > 0;
+  const timeRemaining = useCountdown(state.pausedUntil);
+
+  const statusText = getQueueStatusText({
+    isStopped: state.isStopped,
+    isPaused: state.isPaused,
+    isUploading,
+    isComplete,
+    hasFiles,
+    completedCount: counts.success + counts.failed + counts.duplicate,
+    totalCount: counts.total,
+    timeRemaining,
+  });
 
   const handleFilesSelected = (files: File[]) => {
     const remainingCapacity = MAX_FILES_PER_BATCH - state.files.length;
@@ -98,17 +112,7 @@ function UploadPage() {
               {/* Overall Progress */}
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-sm">
-                  <span className="text-muted-foreground">
-                    {state.isStopped
-                      ? 'Stopped'
-                      : isUploading
-                        ? `Uploading ${counts.success + counts.failed + counts.duplicate}/${counts.total}...`
-                        : state.isPaused
-                          ? 'Paused (rate limited)'
-                          : isComplete
-                            ? 'Upload complete'
-                            : 'Ready to upload'}
-                  </span>
+                  <span className="text-muted-foreground">{statusText}</span>
                   <span className="font-medium">{progress}%</span>
                 </div>
                 <Progress value={progress} />

--- a/apps/web/src/routes/upload.tsx
+++ b/apps/web/src/routes/upload.tsx
@@ -115,7 +115,7 @@ function UploadPage() {
                   <span className="text-muted-foreground">{statusText}</span>
                   <span className="font-medium">{progress}%</span>
                 </div>
-                <Progress value={progress} />
+                <Progress value={progress} variant={state.isStopped ? 'stopped' : 'default'} />
               </div>
 
               {/* Status Summary */}

--- a/apps/web/src/routes/upload.tsx
+++ b/apps/web/src/routes/upload.tsx
@@ -1,18 +1,9 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import {
-  AlertCircle,
-  Check,
-  Copy,
-  FileImage,
-  FileVideo,
-  Loader2,
-  RefreshCw,
-  Trash2,
-} from 'lucide-react';
+import { AlertCircle, Check, Copy, FileImage, FileVideo, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
+import { UploadActionButtons } from '@/components/upload/upload-action-buttons';
 import { UploadDropZone } from '@/components/upload/upload-drop-zone';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { MAX_FILES_PER_BATCH, useUploadQueue } from '@/contexts/upload-queue-context';
@@ -46,13 +37,23 @@ function getStatusIcon(status: string) {
 }
 
 function UploadPage() {
-  const { state, counts, progress, addFiles, clearCompleted, retryFailed, cancelAll } =
-    useUploadQueue();
+  const {
+    state,
+    counts,
+    progress,
+    addFiles,
+    clearCompleted,
+    retryFailed,
+    cancelAll,
+    stopQueue,
+    resumeQueue,
+  } = useUploadQueue();
   const queryClient = useQueryClient();
 
   const hasFiles = state.files.length > 0;
   const isUploading = counts.uploading > 0 || counts.pending > 0;
-  const isComplete = hasFiles && !isUploading && !state.isPaused;
+  const isRunning = isUploading && !state.isPaused && !state.isStopped;
+  const isComplete = hasFiles && !isUploading && !state.isPaused && !state.isStopped;
   const hasFailures = counts.failed > 0;
 
   const handleFilesSelected = (files: File[]) => {
@@ -98,13 +99,15 @@ function UploadPage() {
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-muted-foreground">
-                    {isUploading
-                      ? `Uploading ${counts.success + counts.failed + counts.duplicate}/${counts.total}...`
-                      : state.isPaused
-                        ? 'Paused (rate limited)'
-                        : isComplete
-                          ? 'Upload complete'
-                          : 'Ready to upload'}
+                    {state.isStopped
+                      ? 'Stopped'
+                      : isUploading
+                        ? `Uploading ${counts.success + counts.failed + counts.duplicate}/${counts.total}...`
+                        : state.isPaused
+                          ? 'Paused (rate limited)'
+                          : isComplete
+                            ? 'Upload complete'
+                            : 'Ready to upload'}
                   </span>
                   <span className="font-medium">{progress}%</span>
                 </div>
@@ -170,29 +173,18 @@ function UploadPage() {
               </div>
 
               {/* Action Buttons */}
-              <div className="flex gap-2">
-                {hasFailures && (
-                  <Button
-                    variant="outline"
-                    onClick={retryFailed}
-                    disabled={isUploading}
-                    className="flex-1"
-                  >
-                    <RefreshCw className="mr-2 h-4 w-4" />
-                    Retry failed
-                  </Button>
-                )}
-                {isComplete && (
-                  <Button variant="outline" onClick={clearCompleted} className="flex-1">
-                    <Check className="mr-2 h-4 w-4" />
-                    Clear completed
-                  </Button>
-                )}
-                <Button variant="ghost" onClick={handleClearAll} disabled={isUploading}>
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Clear all
-                </Button>
-              </div>
+              <UploadActionButtons
+                isRunning={isRunning}
+                isPaused={state.isPaused}
+                isStopped={state.isStopped}
+                hasFailures={hasFailures}
+                isComplete={isComplete}
+                onStopQueue={stopQueue}
+                onResumeQueue={resumeQueue}
+                onClearAll={handleClearAll}
+                onRetryFailed={retryFailed}
+                onClearCompleted={clearCompleted}
+              />
             </div>
           )}
         </CardContent>

--- a/apps/web/test/components/upload/upload-action-buttons.test.tsx
+++ b/apps/web/test/components/upload/upload-action-buttons.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { UploadActionButtons } from '@/components/upload/upload-action-buttons';
+
+function renderActionButtons(overrides: Partial<Parameters<typeof UploadActionButtons>[0]> = {}) {
+  const defaultProps = {
+    isRunning: false,
+    isPaused: false,
+    isStopped: false,
+    hasFailures: false,
+    isComplete: false,
+    onStopQueue: vi.fn(),
+    onResumeQueue: vi.fn(),
+    onClearAll: vi.fn(),
+    onRetryFailed: vi.fn(),
+    onClearCompleted: vi.fn(),
+  };
+  return render(<UploadActionButtons {...defaultProps} {...overrides} />);
+}
+
+describe('UploadActionButtons', () => {
+  describe('when queue is running', () => {
+    it('shows Stop uploading button', () => {
+      renderActionButtons({ isRunning: true });
+
+      expect(screen.getByText('Stop uploading')).toBeInTheDocument();
+    });
+
+    it('does not show Clear all button', () => {
+      renderActionButtons({ isRunning: true });
+
+      expect(screen.queryByText('Clear all')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when queue is paused', () => {
+    it('shows Stop uploading button', () => {
+      renderActionButtons({ isPaused: true });
+
+      expect(screen.getByText('Stop uploading')).toBeInTheDocument();
+    });
+
+    it('does not show Clear all button', () => {
+      renderActionButtons({ isPaused: true });
+
+      expect(screen.queryByText('Clear all')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when queue is stopped', () => {
+    it('shows Resume uploading button', () => {
+      renderActionButtons({ isStopped: true });
+
+      expect(screen.getByText('Resume uploading')).toBeInTheDocument();
+    });
+
+    it('shows Clear all button', () => {
+      renderActionButtons({ isStopped: true });
+
+      expect(screen.getByText('Clear all')).toBeInTheDocument();
+    });
+
+    it('does not show Stop uploading button', () => {
+      renderActionButtons({ isStopped: true });
+
+      expect(screen.queryByText('Stop uploading')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('button click handlers', () => {
+    it('calls onStopQueue when Stop uploading is clicked', () => {
+      const onStopQueue = vi.fn();
+      renderActionButtons({ isRunning: true, onStopQueue });
+
+      fireEvent.click(screen.getByText('Stop uploading'));
+
+      expect(onStopQueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onResumeQueue when Resume uploading is clicked', () => {
+      const onResumeQueue = vi.fn();
+      renderActionButtons({ isStopped: true, onResumeQueue });
+
+      fireEvent.click(screen.getByText('Resume uploading'));
+
+      expect(onResumeQueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClearAll when Clear all is clicked while stopped', () => {
+      const onClearAll = vi.fn();
+      renderActionButtons({ isStopped: true, onClearAll });
+
+      fireEvent.click(screen.getByText('Clear all'));
+
+      expect(onClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when queue is idle/complete', () => {
+    it('shows Clear all button when complete', () => {
+      renderActionButtons({ isComplete: true });
+
+      expect(screen.getByText('Clear all')).toBeInTheDocument();
+    });
+
+    it('does not show Stop uploading button', () => {
+      renderActionButtons({ isComplete: true });
+
+      expect(screen.queryByText('Stop uploading')).not.toBeInTheDocument();
+    });
+
+    it('does not show Resume uploading button', () => {
+      renderActionButtons({ isComplete: true });
+
+      expect(screen.queryByText('Resume uploading')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with failures', () => {
+    it('shows Retry failed button disabled when running with failures', () => {
+      renderActionButtons({ isRunning: true, hasFailures: true });
+
+      const button = screen.getByText('Retry failed').closest('button');
+      expect(button).toBeDisabled();
+    });
+
+    it('shows Retry failed button enabled when stopped with failures', () => {
+      renderActionButtons({ isStopped: true, hasFailures: true });
+
+      const button = screen.getByText('Retry failed').closest('button');
+      expect(button).not.toBeDisabled();
+    });
+
+    it('calls onRetryFailed when Retry failed is clicked', () => {
+      const onRetryFailed = vi.fn();
+      renderActionButtons({ hasFailures: true, onRetryFailed });
+
+      fireEvent.click(screen.getByText('Retry failed'));
+
+      expect(onRetryFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show Retry failed when no failures', () => {
+      renderActionButtons({ hasFailures: false });
+
+      expect(screen.queryByText('Retry failed')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/test/components/upload/upload-queue-toast.test.tsx
+++ b/apps/web/test/components/upload/upload-queue-toast.test.tsx
@@ -236,4 +236,195 @@ describe('UploadQueueToast', () => {
 
     expect(onClearCompleted).toHaveBeenCalledTimes(1);
   });
+
+  it('shows Stop button when queue is running', () => {
+    const files: QueuedFile[] = [
+      createQueuedFile('1', 'uploading'),
+      createQueuedFile('2', 'pending'),
+    ];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 2, pending: 1, uploading: 1, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={false}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('stop-queue-button')).toBeInTheDocument();
+  });
+
+  it('shows Stop button when queue is paused', () => {
+    const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
+    const pausedUntil = Date.now() + 45000;
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 1, pending: 1, uploading: 0, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={true}
+        isStopped={false}
+        pausedUntil={pausedUntil}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('stop-queue-button')).toBeInTheDocument();
+  });
+
+  it('does not show Stop button when queue is stopped', () => {
+    const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 1, pending: 1, uploading: 0, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={true}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('stop-queue-button')).not.toBeInTheDocument();
+  });
+
+  it('clicking Stop dispatches onStopQueue', () => {
+    const onStopQueue = vi.fn();
+    const files: QueuedFile[] = [
+      createQueuedFile('1', 'uploading'),
+      createQueuedFile('2', 'pending'),
+    ];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 2, pending: 1, uploading: 1, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={false}
+        pausedUntil={null}
+        onStopQueue={onStopQueue}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('stop-queue-button'));
+    expect(onStopQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Stopped label and Resume button when queue is stopped', () => {
+    const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 1, pending: 1, uploading: 0, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={true}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Stopped')).toBeInTheDocument();
+    expect(screen.getByTestId('resume-queue-button')).toBeInTheDocument();
+  });
+
+  it('does not show Resume button when queue is running', () => {
+    const files: QueuedFile[] = [
+      createQueuedFile('1', 'uploading'),
+      createQueuedFile('2', 'pending'),
+    ];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 2, pending: 1, uploading: 1, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={false}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByTestId('resume-queue-button')).not.toBeInTheDocument();
+  });
+
+  it('clicking Resume dispatches onResumeQueue', () => {
+    const onResumeQueue = vi.fn();
+    const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 1, pending: 1, uploading: 0, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={true}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={onResumeQueue}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('resume-queue-button'));
+    expect(onResumeQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Stopped header text when queue is stopped', () => {
+    const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 1, pending: 1, uploading: 0, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={true}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Stopped')).toBeInTheDocument();
+  });
 });

--- a/apps/web/test/components/upload/upload-queue-toast.test.tsx
+++ b/apps/web/test/components/upload/upload-queue-toast.test.tsx
@@ -406,6 +406,79 @@ describe('UploadQueueToast', () => {
     expect(onResumeQueue).toHaveBeenCalledTimes(1);
   });
 
+  it('applies stopped variant to progress bar when queue is stopped', () => {
+    const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 1, pending: 1, uploading: 0, success: 0, failed: 0, duplicate: 0 }}
+        progress={50}
+        isPaused={false}
+        isStopped={true}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    const indicator = screen.getByRole('progressbar').querySelector('[data-slot="progress-indicator"]');
+    expect(indicator).toHaveAttribute('data-variant', 'stopped');
+  });
+
+  it('applies default variant to progress bar when queue is running', () => {
+    const files: QueuedFile[] = [
+      createQueuedFile('1', 'uploading'),
+      createQueuedFile('2', 'pending'),
+    ];
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 2, pending: 1, uploading: 1, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={false}
+        isStopped={false}
+        pausedUntil={null}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    const indicator = screen.getByRole('progressbar').querySelector('[data-slot="progress-indicator"]');
+    expect(indicator).not.toHaveAttribute('data-variant', 'stopped');
+  });
+
+  it('applies default variant to progress bar when queue is paused', () => {
+    const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
+    const pausedUntil = Date.now() + 45000;
+
+    render(
+      <UploadQueueToast
+        files={files}
+        counts={{ total: 1, pending: 1, uploading: 0, success: 0, failed: 0, duplicate: 0 }}
+        progress={0}
+        isPaused={true}
+        isStopped={false}
+        pausedUntil={pausedUntil}
+        onStopQueue={vi.fn()}
+        onResumeQueue={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onClearCompleted={vi.fn()}
+        onNavigateToUpload={vi.fn()}
+      />
+    );
+
+    const indicator = screen.getByRole('progressbar').querySelector('[data-slot="progress-indicator"]');
+    expect(indicator).not.toHaveAttribute('data-variant', 'stopped');
+  });
+
   it('shows Stopped header text when queue is stopped', () => {
     const files: QueuedFile[] = [createQueuedFile('1', 'pending')];
 

--- a/apps/web/test/contexts/upload-queue-reducer.test.ts
+++ b/apps/web/test/contexts/upload-queue-reducer.test.ts
@@ -17,6 +17,7 @@ function createInitialState(): UploadQueueState {
     files: [],
     isProcessing: false,
     isPaused: false,
+    isStopped: false,
     pausedUntil: null,
   };
 }
@@ -231,6 +232,7 @@ describe('uploadQueueReducer', () => {
 
       const newState = uploadQueueReducer(state, {
         type: 'RESUME_QUEUE',
+        payload: { now: Date.now() },
       });
 
       expect(newState.isPaused).toBe(false);
@@ -301,6 +303,7 @@ describe('uploadQueueReducer', () => {
         ],
         isProcessing: true,
         isPaused: false,
+        isStopped: false,
         pausedUntil: null,
       };
 
@@ -311,6 +314,7 @@ describe('uploadQueueReducer', () => {
       expect(newState.files).toHaveLength(0);
       expect(newState.isProcessing).toBe(false);
       expect(newState.isPaused).toBe(false);
+      expect(newState.isStopped).toBe(false);
     });
   });
 
@@ -324,6 +328,264 @@ describe('uploadQueueReducer', () => {
       });
 
       expect(newState.isProcessing).toBe(true);
+    });
+  });
+
+  describe('STOP_QUEUE', () => {
+    it('transitions from running to stopped', () => {
+      const state: UploadQueueState = {
+        ...createInitialState(),
+        isProcessing: true,
+        files: [{ id: 'file-1', file: createMockFile(), status: 'uploading' }],
+      };
+
+      const newState = uploadQueueReducer(state, { type: 'STOP_QUEUE' });
+
+      expect(newState.isStopped).toBe(true);
+      expect(newState.isProcessing).toBe(true);
+    });
+
+    it('transitions from paused to stopped preserving pausedUntil', () => {
+      const pausedUntil = Date.now() + 60000;
+      const state: UploadQueueState = {
+        ...createInitialState(),
+        isProcessing: true,
+        isPaused: true,
+        pausedUntil,
+        files: [
+          {
+            id: 'file-1',
+            file: createMockFile(),
+            status: 'failed',
+            error: { type: 'rate_limit', message: 'Rate limited', retryAfter: 60 },
+          },
+        ],
+      };
+
+      const newState = uploadQueueReducer(state, { type: 'STOP_QUEUE' });
+
+      expect(newState.isStopped).toBe(true);
+      expect(newState.isPaused).toBe(false);
+      expect(newState.pausedUntil).toBe(pausedUntil);
+    });
+  });
+
+  describe('RESUME_QUEUE', () => {
+    it('transitions from stopped to running when outside rate limit window', () => {
+      const state: UploadQueueState = {
+        ...createInitialState(),
+        isProcessing: true,
+        isStopped: true,
+        isPaused: false,
+        pausedUntil: null,
+        files: [{ id: 'file-1', file: createMockFile(), status: 'pending' }],
+      };
+
+      const newState = uploadQueueReducer(state, {
+        type: 'RESUME_QUEUE',
+        payload: { now: Date.now() },
+      });
+
+      expect(newState.isStopped).toBe(false);
+      expect(newState.isPaused).toBe(false);
+      expect(newState.pausedUntil).toBe(null);
+    });
+
+    it('transitions from stopped to paused when inside rate limit window', () => {
+      const now = Date.now();
+      const pausedUntil = now + 30000;
+      const state: UploadQueueState = {
+        ...createInitialState(),
+        isProcessing: true,
+        isStopped: true,
+        isPaused: false,
+        pausedUntil,
+        files: [{ id: 'file-1', file: createMockFile(), status: 'pending' }],
+      };
+
+      const newState = uploadQueueReducer(state, {
+        type: 'RESUME_QUEUE',
+        payload: { now },
+      });
+
+      expect(newState.isStopped).toBe(false);
+      expect(newState.isPaused).toBe(true);
+      expect(newState.pausedUntil).toBe(pausedUntil);
+    });
+
+    it('preserves existing pause behavior when not stopped', () => {
+      const state: UploadQueueState = {
+        ...createInitialState(),
+        isProcessing: true,
+        isPaused: true,
+        pausedUntil: Date.now() + 60000,
+      };
+
+      const newState = uploadQueueReducer(state, {
+        type: 'RESUME_QUEUE',
+        payload: { now: Date.now() },
+      });
+
+      expect(newState.isPaused).toBe(false);
+      expect(newState.pausedUntil).toBe(null);
+      expect(newState.isStopped).toBe(false);
+    });
+
+    it('does not retry previously failed files on resume from stopped', () => {
+      const state: UploadQueueState = {
+        ...createInitialState(),
+        isProcessing: true,
+        isStopped: true,
+        isPaused: false,
+        pausedUntil: null,
+        files: [
+          { id: 'file-1', file: createMockFile('a.jpg'), status: 'pending' },
+          {
+            id: 'file-2',
+            file: createMockFile('b.jpg'),
+            status: 'failed',
+            error: { type: 'server', message: 'Error' },
+          },
+          { id: 'file-3', file: createMockFile('c.jpg'), status: 'success' },
+        ],
+      };
+
+      const newState = uploadQueueReducer(state, {
+        type: 'RESUME_QUEUE',
+        payload: { now: Date.now() },
+      });
+
+      expect(newState.files[0].status).toBe('pending');
+      expect(newState.files[1].status).toBe('failed');
+      expect(newState.files[2].status).toBe('success');
+    });
+  });
+
+  describe('auto-reset to idle from stopped', () => {
+    it('resets to idle when last uploading file succeeds in stopped state', () => {
+      const state: UploadQueueState = {
+        files: [
+          { id: 'file-1', file: createMockFile('a.jpg'), status: 'failed', error: { type: 'server', message: 'Error' } },
+          { id: 'file-2', file: createMockFile('b.jpg'), status: 'uploading' },
+        ],
+        isProcessing: true,
+        isPaused: false,
+        isStopped: true,
+        pausedUntil: null,
+      };
+
+      const newState = uploadQueueReducer(state, {
+        type: 'UPLOAD_SUCCESS',
+        payload: { fileId: 'file-2', response: { wallpaperId: 'wlpr_1', userId: 'u1', uploadState: 'processing', fileType: 'image', mimeType: 'image/jpeg', fileSizeBytes: 1024, width: 1920, height: 1080, aspectRatio: 1.78, uploadedAt: '2024-01-01T00:00:00Z' } },
+      });
+
+      expect(newState.files.length).toBe(0);
+      expect(newState.isProcessing).toBe(false);
+      expect(newState.isStopped).toBe(false);
+      expect(newState.isPaused).toBe(false);
+      expect(newState.pausedUntil).toBe(null);
+    });
+
+    it('resets to idle when last uploading file fails in stopped state', () => {
+      const state: UploadQueueState = {
+        files: [
+          { id: 'file-1', file: createMockFile('a.jpg'), status: 'success' },
+          { id: 'file-2', file: createMockFile('b.jpg'), status: 'uploading' },
+        ],
+        isProcessing: true,
+        isPaused: false,
+        isStopped: true,
+        pausedUntil: null,
+      };
+
+      const newState = uploadQueueReducer(state, {
+        type: 'UPLOAD_FAILED',
+        payload: { fileId: 'file-2', error: { type: 'server', message: 'Error' } },
+      });
+
+      expect(newState.files.length).toBe(0);
+      expect(newState.isProcessing).toBe(false);
+      expect(newState.isStopped).toBe(false);
+    });
+
+    it('does not auto-reset when pending files remain in stopped state', () => {
+      const state: UploadQueueState = {
+        files: [
+          { id: 'file-1', file: createMockFile('a.jpg'), status: 'pending' },
+          { id: 'file-2', file: createMockFile('b.jpg'), status: 'uploading' },
+        ],
+        isProcessing: true,
+        isPaused: false,
+        isStopped: true,
+        pausedUntil: null,
+      };
+
+      const newState = uploadQueueReducer(state, {
+        type: 'UPLOAD_SUCCESS',
+        payload: { fileId: 'file-2', response: { wallpaperId: 'wlpr_1', userId: 'u1', uploadState: 'processing', fileType: 'image', mimeType: 'image/jpeg', fileSizeBytes: 1024, width: 1920, height: 1080, aspectRatio: 1.78, uploadedAt: '2024-01-01T00:00:00Z' } },
+      });
+
+      expect(newState.files.length).toBe(2);
+      expect(newState.isStopped).toBe(true);
+      expect(newState.files[0].status).toBe('pending');
+      expect(newState.files[1].status).toBe('success');
+    });
+  });
+
+  describe('pausedUntil persistence across STOP_QUEUE and RESUME_QUEUE', () => {
+    it('preserves pausedUntil across stop and resume cycle inside rate limit window', () => {
+      const now = Date.now();
+      const pausedUntil = now + 30000;
+
+      const stoppedState = uploadQueueReducer(
+        {
+          ...createInitialState(),
+          isProcessing: true,
+          isPaused: true,
+          pausedUntil,
+          files: [
+            {
+              id: 'file-1',
+              file: createMockFile(),
+              status: 'failed',
+              error: { type: 'rate_limit', message: 'Rate limited', retryAfter: 30 },
+            },
+          ],
+        },
+        { type: 'STOP_QUEUE' }
+      );
+
+      expect(stoppedState.isStopped).toBe(true);
+      expect(stoppedState.pausedUntil).toBe(pausedUntil);
+
+      const resumedState = uploadQueueReducer(stoppedState, {
+        type: 'RESUME_QUEUE',
+        payload: { now },
+      });
+
+      expect(resumedState.isStopped).toBe(false);
+      expect(resumedState.isPaused).toBe(true);
+      expect(resumedState.pausedUntil).toBe(pausedUntil);
+    });
+
+    it('clears pausedUntil when resuming outside rate limit window', () => {
+      const now = Date.now();
+      const pausedUntil = now - 1000;
+
+      const stoppedState = uploadQueueReducer(
+        {
+          ...createInitialState(),
+          isProcessing: true,
+          isStopped: true,
+          isPaused: false,
+          pausedUntil,
+          files: [{ id: 'file-1', file: createMockFile(), status: 'pending' }],
+        },
+        { type: 'RESUME_QUEUE', payload: { now } }
+      );
+
+      expect(stoppedState.isPaused).toBe(false);
+      expect(stoppedState.pausedUntil).toBe(null);
     });
   });
 });

--- a/apps/web/test/hooks/useCountdown.test.ts
+++ b/apps/web/test/hooks/useCountdown.test.ts
@@ -1,0 +1,88 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useCountdown } from '@/hooks/useCountdown';
+
+describe('useCountdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns null when pausedUntil is null', () => {
+    const { result } = renderHook(() => useCountdown(null));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns formatted time remaining when pausedUntil is in the future', () => {
+    const pausedUntil = Date.now() + 45000;
+    const { result } = renderHook(() => useCountdown(pausedUntil));
+    expect(result.current).toBe('45s');
+  });
+
+  it('returns null when pausedUntil is in the past', () => {
+    const pausedUntil = Date.now() - 1000;
+    const { result } = renderHook(() => useCountdown(pausedUntil));
+    expect(result.current).toBeNull();
+  });
+
+  it('decrements every second', () => {
+    const pausedUntil = Date.now() + 10000;
+    const { result } = renderHook(() => useCountdown(pausedUntil));
+
+    expect(result.current).toBe('10s');
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe('9s');
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toBe('4s');
+  });
+
+  it('returns null when countdown reaches zero', () => {
+    const pausedUntil = Date.now() + 3000;
+    const { result } = renderHook(() => useCountdown(pausedUntil));
+
+    expect(result.current).toBe('3s');
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it('updates when pausedUntil changes', () => {
+    const { result, rerender } = renderHook(
+      ({ pausedUntil }: { pausedUntil: number | null }) => useCountdown(pausedUntil),
+      { initialProps: { pausedUntil: null } }
+    );
+
+    expect(result.current).toBeNull();
+
+    const newPausedUntil = Date.now() + 60000;
+    rerender({ pausedUntil: newPausedUntil });
+    expect(result.current).toBe('1m 0s');
+  });
+
+  it('formats minutes and seconds correctly', () => {
+    const pausedUntil = Date.now() + 125000;
+    const { result } = renderHook(() => useCountdown(pausedUntil));
+    expect(result.current).toBe('2m 5s');
+  });
+
+  it('cleans up interval on unmount', () => {
+    const pausedUntil = Date.now() + 30000;
+    const { unmount } = renderHook(() => useCountdown(pausedUntil));
+
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/apps/web/test/lib/utils/upload-queue.test.ts
+++ b/apps/web/test/lib/utils/upload-queue.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import { formatTimeRemaining, getQueueStatusText } from '@/lib/utils/upload-queue';
+
+describe('formatTimeRemaining', () => {
+  it('formats seconds less than 60', () => {
+    expect(formatTimeRemaining(45000)).toBe('45s');
+  });
+
+  it('formats exactly 60 seconds as 1m 0s', () => {
+    expect(formatTimeRemaining(60000)).toBe('1m 0s');
+  });
+
+  it('formats minutes and seconds', () => {
+    expect(formatTimeRemaining(3549500)).toBe('59m 10s');
+  });
+
+  it('formats zero ms as 0s', () => {
+    expect(formatTimeRemaining(0)).toBe('0s');
+  });
+
+  it('rounds up partial seconds', () => {
+    expect(formatTimeRemaining(1500)).toBe('2s');
+  });
+
+  it('clamps negative values to 0s', () => {
+    expect(formatTimeRemaining(-5000)).toBe('0s');
+  });
+});
+
+describe('getQueueStatusText', () => {
+  it('returns "Stopped" when queue is stopped', () => {
+    expect(
+      getQueueStatusText({
+        isStopped: true,
+        isPaused: false,
+        isUploading: true,
+        isComplete: false,
+        hasFiles: true,
+        completedCount: 3,
+        totalCount: 10,
+        timeRemaining: null,
+      })
+    ).toBe('Stopped');
+  });
+
+  it('returns "Uploading X/Y…" when running', () => {
+    expect(
+      getQueueStatusText({
+        isStopped: false,
+        isPaused: false,
+        isUploading: true,
+        isComplete: false,
+        hasFiles: true,
+        completedCount: 3,
+        totalCount: 10,
+        timeRemaining: null,
+      })
+    ).toBe('Uploading 3/10...');
+  });
+
+  it('returns "Paused (resuming in Xm Xs)" when paused with time remaining', () => {
+    expect(
+      getQueueStatusText({
+        isStopped: false,
+        isPaused: true,
+        isUploading: true,
+        isComplete: false,
+        hasFiles: true,
+        completedCount: 2,
+        totalCount: 10,
+        timeRemaining: '2m 30s',
+      })
+    ).toBe('Paused (resuming in 2m 30s)');
+  });
+
+  it('returns "Paused (rate limited)" when paused without time remaining', () => {
+    expect(
+      getQueueStatusText({
+        isStopped: false,
+        isPaused: true,
+        isUploading: true,
+        isComplete: false,
+        hasFiles: true,
+        completedCount: 2,
+        totalCount: 10,
+        timeRemaining: null,
+      })
+    ).toBe('Paused (rate limited)');
+  });
+
+  it('returns "Upload complete" when complete', () => {
+    expect(
+      getQueueStatusText({
+        isStopped: false,
+        isPaused: false,
+        isUploading: false,
+        isComplete: true,
+        hasFiles: true,
+        completedCount: 10,
+        totalCount: 10,
+        timeRemaining: null,
+      })
+    ).toBe('Upload complete');
+  });
+
+  it('returns "Ready to upload" when idle with files', () => {
+    expect(
+      getQueueStatusText({
+        isStopped: false,
+        isPaused: false,
+        isUploading: false,
+        isComplete: false,
+        hasFiles: true,
+        completedCount: 0,
+        totalCount: 5,
+        timeRemaining: null,
+      })
+    ).toBe('Ready to upload');
+  });
+
+  it('prioritizes stopped over paused when both flags are set', () => {
+    expect(
+      getQueueStatusText({
+        isStopped: true,
+        isPaused: true,
+        isUploading: true,
+        isComplete: false,
+        hasFiles: true,
+        completedCount: 3,
+        totalCount: 10,
+        timeRemaining: null,
+      })
+    ).toBe('Stopped');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the "stop uploading" feature from PRD #82, allowing users to halt the upload queue without removing pending files.

Closes #82, closes #83, closes #84, closes #85, closes #86, closes #87

### What changed

- **#83 — STOPPED state in upload queue reducer**: Added `STOP_QUEUE` and `RESUME_QUEUE` actions to the reducer. Stop transitions from `running`/`paused` to `stopped`, preserving `pausedUntil` for rate-limit cooldown. Resume transitions back to `running` (or `paused` if still within the rate-limit window). Auto-resets to `idle` when all files reach terminal states while stopped.
- **#84 — Contextual Stop/Resume/Clear buttons**: The upload page now shows "Stop uploading" while running/paused, and both "Resume uploading" and "Clear all" while stopped — replacing the single "Clear all" that appeared in all states.
- **#85 — Queue status text with live countdown**: Added `getQueueStatusText()` utility and `useCountdown` hook. The upload page and toast now show contextual status: "Uploading X/Y files", "Paused (resuming in Xm Ys)", "Stopped", or "Upload complete".
- **#86 — Stop and Resume controls in toast**: The floating toast shows a "Stop" button while running/paused and a "Stopped" label + "Resume" button while stopped.
- **#87 — Progress bar amber style for stopped state**: The `Progress` component gains a `variant` prop. When `stopped`, the bar uses `bg-amber-500` instead of `bg-primary`. Applied in both the toast and the upload page.

### Test coverage

- Reducer unit tests: 25 tests covering all state transitions including stop/resume, rate-limit interaction, and auto-reset
- Status text utility tests: 13 tests for `formatTimeRemaining` and `getQueueStatusText`
- `useCountdown` hook tests: 8 tests
- Upload action buttons tests: 17 tests
- Toast component tests: 20 tests including progress bar variant, stop/resume buttons, and status text