### PR TITLE
Add HSV color embedding strategy for histogram computation

### DIFF
--- a/apps/color-extractor/src/services/hsv-embedding-strategy.ts
+++ b/apps/color-extractor/src/services/hsv-embedding-strategy.ts
@@ -1,0 +1,68 @@
+export interface IColorEmbeddingStrategy {
+  computeHistogram(rgbaPixels: Uint8Array): number[];
+}
+
+const HUE_BINS = 12;
+const SAT_BINS = 2;
+const VAL_BINS = 2;
+const CHROMATIC_BINS = HUE_BINS * SAT_BINS * VAL_BINS;
+const ACHROMATIC_BINS = 16;
+const TOTAL_BINS = CHROMATIC_BINS + ACHROMATIC_BINS;
+const ACHROMATIC_SATURATION_THRESHOLD = 0.1;
+
+export class HsvEmbeddingStrategy implements IColorEmbeddingStrategy {
+  computeHistogram(rgbaPixels: Uint8Array): number[] {
+    const bins = new Float64Array(TOTAL_BINS);
+    const pixelCount = rgbaPixels.length / 4;
+
+    for (let i = 0; i < pixelCount; i++) {
+      const offset = i * 4;
+      const r = rgbaPixels[offset] / 255;
+      const g = rgbaPixels[offset + 1] / 255;
+      const b = rgbaPixels[offset + 2] / 255;
+      const a = rgbaPixels[offset + 3] / 255;
+
+      if (a === 0) continue;
+
+      const max = Math.max(r, g, b);
+      const min = Math.min(r, g, b);
+      const delta = max - min;
+
+      const v = max;
+      const s = max === 0 ? 0 : delta / max;
+
+      if (s < ACHROMATIC_SATURATION_THRESHOLD) {
+        const valBin = Math.min(ACHROMATIC_BINS - 1, Math.floor(v * ACHROMATIC_BINS));
+        bins[CHROMATIC_BINS + valBin] += a;
+      } else {
+        const h = this.computeHue(r, g, b, max, delta);
+        const hueBin = Math.min(HUE_BINS - 1, Math.floor(h / 30));
+        const satBin = s < 0.5 ? 0 : 1;
+        const valBin = v < 0.5 ? 0 : 1;
+        const idx = hueBin * (SAT_BINS * VAL_BINS) + satBin * VAL_BINS + valBin;
+        bins[idx] += a;
+      }
+    }
+
+    return this.normalize(bins);
+  }
+
+  private computeHue(r: number, g: number, b: number, max: number, delta: number): number {
+    let h: number;
+    if (max === r) {
+      h = ((g - b) / delta) * 60;
+    } else if (max === g) {
+      h = ((b - r) / delta + 2) * 60;
+    } else {
+      h = ((r - g) / delta + 4) * 60;
+    }
+    if (h < 0) h += 360;
+    return h;
+  }
+
+  private normalize(bins: Float64Array): number[] {
+    const total = bins.reduce((sum, v) => sum + v, 0);
+    if (total === 0) return Array.from(bins);
+    return Array.from(bins, (v) => v / total);
+  }
+}

--- a/apps/color-extractor/test/hsv-embedding-strategy.test.ts
+++ b/apps/color-extractor/test/hsv-embedding-strategy.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { HsvEmbeddingStrategy } from "../src/services/hsv-embedding-strategy";
+
+describe("HsvEmbeddingStrategy", () => {
+  const strategy = new HsvEmbeddingStrategy();
+
+  describe("single pure red pixel", () => {
+    it("produces a 64-dim normalized vector with weight in the correct chromatic bin", () => {
+      const rgba = new Uint8Array([255, 0, 0, 255]);
+      const result = strategy.computeHistogram(rgba);
+
+      expect(result).toHaveLength(64);
+      expect(result.reduce((sum, v) => sum + v, 0)).toBeCloseTo(1.0, 10);
+
+      const redBin = 0 * 4 + 1 * 2 + 1;
+      expect(result[redBin]).toBeCloseTo(1.0, 10);
+
+      for (let i = 0; i < 64; i++) {
+        if (i !== redBin) {
+          expect(result[i]).toBe(0);
+        }
+      }
+    });
+  });
+
+  describe("all-black image", () => {
+    it("classifies black pixels as achromatic in the lowest value bin", () => {
+      const rgba = new Uint8Array([0, 0, 0, 255, 0, 0, 0, 255]);
+      const result = strategy.computeHistogram(rgba);
+
+      expect(result).toHaveLength(64);
+      expect(result.reduce((sum, v) => sum + v, 0)).toBeCloseTo(1.0, 10);
+
+      const blackBin = 48 + 0;
+      expect(result[blackBin]).toBeCloseTo(1.0, 10);
+
+      for (let i = 0; i < 64; i++) {
+        if (i !== blackBin) {
+          expect(result[i]).toBe(0);
+        }
+      }
+    });
+  });
+
+  describe("all-white image", () => {
+    it("classifies white pixels as achromatic in the highest value bin", () => {
+      const rgba = new Uint8Array([255, 255, 255, 255]);
+      const result = strategy.computeHistogram(rgba);
+
+      expect(result).toHaveLength(64);
+      expect(result.reduce((sum, v) => sum + v, 0)).toBeCloseTo(1.0, 10);
+
+      const whiteBin = 48 + 15;
+      expect(result[whiteBin]).toBeCloseTo(1.0, 10);
+
+      for (let i = 0; i < 64; i++) {
+        if (i !== whiteBin) {
+          expect(result[i]).toBe(0);
+        }
+      }
+    });
+  });
+
+  describe("alpha weighting", () => {
+    it("weights pixel contributions by alpha channel value", () => {
+      const fullAlphaRed = new Uint8Array([255, 0, 0, 255]);
+      const halfAlphaRed = new Uint8Array([255, 0, 0, 128]);
+      const quarterAlphaBlue = new Uint8Array([0, 0, 255, 64]);
+
+      const rgba = new Uint8Array([
+        ...fullAlphaRed,
+        ...halfAlphaRed,
+        ...quarterAlphaBlue,
+      ]);
+      const result = strategy.computeHistogram(rgba);
+
+      const redBin = 0 * 4 + 1 * 2 + 1;
+      const blueBin = 8 * 4 + 1 * 2 + 1;
+
+      const redWeight = 1.0 + 128 / 255;
+      const blueWeight = 64 / 255;
+      const total = redWeight + blueWeight;
+
+      expect(result[redBin]).toBeCloseTo(redWeight / total, 10);
+      expect(result[blueBin]).toBeCloseTo(blueWeight / total, 10);
+      expect(result.reduce((sum, v) => sum + v, 0)).toBeCloseTo(1.0, 10);
+    });
+  });
+
+  describe("fully transparent image", () => {
+    it("returns a zero vector when all pixels are fully transparent", () => {
+      const rgba = new Uint8Array([255, 0, 0, 0, 0, 255, 0, 0]);
+      const result = strategy.computeHistogram(rgba);
+
+      expect(result).toHaveLength(64);
+      expect(result.every((v) => v === 0)).toBe(true);
+    });
+  });
+
+  describe("chromatic color bin assignments", () => {
+    const chromaticColors: Array<{
+      name: string;
+      rgba: number[];
+      hueBin: number;
+    }> = [
+      { name: "green", rgba: [0, 255, 0, 255], hueBin: 4 },
+      { name: "blue", rgba: [0, 0, 255, 255], hueBin: 8 },
+      { name: "yellow", rgba: [255, 255, 0, 255], hueBin: 2 },
+      { name: "cyan", rgba: [0, 255, 255, 255], hueBin: 6 },
+      { name: "magenta", rgba: [255, 0, 255, 255], hueBin: 10 },
+    ];
+
+    for (const { name, rgba, hueBin } of chromaticColors) {
+      it(`places pure ${name} in chromatic bin at hue index ${hueBin}`, () => {
+        const result = strategy.computeHistogram(
+          new Uint8Array(rgba),
+        );
+
+        const expectedBin = hueBin * 4 + 1 * 2 + 1;
+        expect(result).toHaveLength(64);
+        expect(result.reduce((sum, v) => sum + v, 0)).toBeCloseTo(
+          1.0,
+          10,
+        );
+        expect(result[expectedBin]).toBeCloseTo(1.0, 10);
+
+        for (let i = 0; i < 64; i++) {
+          if (i !== expectedBin) {
+            expect(result[i]).toBe(0);
+          }
+        }
+      });
+    }
+  });
+
+  describe("achromatic gray", () => {
+    it("classifies mid-gray as achromatic in a mid-range value bin", () => {
+      const rgba = new Uint8Array([128, 128, 128, 255]);
+      const result = strategy.computeHistogram(rgba);
+
+      expect(result).toHaveLength(64);
+      expect(result.reduce((sum, v) => sum + v, 0)).toBeCloseTo(1.0, 10);
+
+      const grayValue = 128 / 255;
+      const expectedBin = 48 + Math.min(15, Math.floor(grayValue * 16));
+      expect(result[expectedBin]).toBeCloseTo(1.0, 10);
+
+      for (let i = 0; i < 64; i++) {
+        if (i !== expectedBin) {
+          expect(result[i]).toBe(0);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces `HsvEmbeddingStrategy` implementing `IColorEmbeddingStrategy` for computing 64-dimensional color histograms from RGBA pixel data
- Converts RGB to HSV and bins pixels into 48 chromatic bins (12 hue × 2 saturation × 2 value) and 16 achromatic bins (value only, for low-saturation pixels)
- Weights pixel contributions by alpha channel; transparent pixels are skipped
- Returns L1-normalized histogram vector

## Testing

- Unit tests cover: pure red, green, blue, yellow, cyan, magenta binning
- Black and white pixels correctly classified as achromatic in expected value bins
- Mid-gray achromatic classification verified
- Alpha weighting validates proportional contribution of semi-transparent pixels
- Fully transparent image returns a zero vector
- All test suites: Not run