### PR TITLE
Use search_after cursors for GraphQL wallpaper pagination

### DIFF
--- a/apps/gateway/src/graphql/resolvers.ts
+++ b/apps/gateway/src/graphql/resolvers.ts
@@ -2,7 +2,7 @@ import { Attributes, recordCounter, recordHistogram, withSpan } from '@wallpaper
 import { inject, singleton } from 'tsyringe';
 import type { Config } from '../config.js';
 import { WallpaperRepository } from '../repositories/wallpaper.repository.js';
-import { CursorService } from '../services/cursor.service.js';
+import { CursorService, type CursorValue } from '../services/cursor.service.js';
 import { GatewayAttributes } from '../telemetry/attributes.js';
 
 /**
@@ -94,6 +94,7 @@ export class Resolvers {
    */
   private async searchWallpapers(args: SearchArgs) {
     const limit = args.first ?? args.last ?? 10;
+    const isBackwardPagination = args.last !== undefined && args.before !== undefined;
 
     return await withSpan(
       'graphql.resolve.searchWallpapers',
@@ -108,31 +109,33 @@ export class Resolvers {
         const startTime = Date.now();
 
         // Decode cursor if provided
-        let offset = 0;
+        let searchAfter: CursorValue[] | undefined;
         if (args.after) {
-          offset = this.cursorService.decode(args.after);
+          searchAfter = this.cursorService.decode(args.after);
         } else if (args.before) {
-          offset = this.cursorService.decode(args.before);
+          searchAfter = this.cursorService.decode(args.before);
         }
 
-        // If using 'last', we need to adjust offset for backward pagination
-        if (args.last && args.before) {
-          offset = Math.max(0, offset - args.last);
-        }
+        span.setAttribute('search.cursor.present', searchAfter ? 'true' : 'false');
 
-        span.setAttribute(GatewayAttributes.SEARCH_OFFSET, offset);
-
-        // Search with offset and limit
+        // Backward pagination walks the same cursor values in reverse order.
         const result = await this.repository.search({
           userId: args.filter?.userId,
           variantFilters: args.filter?.variants,
-          from: offset,
+          searchAfter,
           size: limit + 1, // Fetch one extra to determine hasNextPage
+          sortOrder: isBackwardPagination ? 'desc' : 'asc',
         });
 
         // Check if there are more results
         const hasMore = result.documents.length > limit;
-        const documents = hasMore ? result.documents.slice(0, limit) : result.documents;
+        let documents = hasMore ? result.documents.slice(0, limit) : result.documents;
+        let cursorValues = hasMore ? result.cursorValues.slice(0, limit) : result.cursorValues;
+
+        if (isBackwardPagination) {
+          documents = [...documents].reverse();
+          cursorValues = [...cursorValues].reverse();
+        }
 
         // Attach wallpaperId to variants for URL resolution
         const edges = documents.map((doc: Wallpaper) => ({
@@ -146,12 +149,14 @@ export class Resolvers {
         }));
 
         // Generate cursors
-        const startCursor = edges.length > 0 ? this.cursorService.encode(offset) : null;
-        const endCursor =
-          edges.length > 0 ? this.cursorService.encode(offset + edges.length) : null;
+        const startCursor = cursorValues[0] ? this.cursorService.encode(cursorValues[0]) : null;
+        const lastCursorValues = cursorValues.at(-1);
+        const endCursor = lastCursorValues ? this.cursorService.encode(lastCursorValues) : null;
 
-        const hasNextPage = hasMore && !args.last;
-        const hasPreviousPage = offset > 0;
+        const hasNextPage = isBackwardPagination
+          ? Boolean(args.before && edges.length > 0)
+          : hasMore;
+        const hasPreviousPage = isBackwardPagination ? hasMore : Boolean(args.after);
 
         // Record span attributes and metrics
         span.setAttribute(GatewayAttributes.SEARCH_TOTAL_RESULTS, result.total);

--- a/apps/gateway/src/repositories/wallpaper.repository.ts
+++ b/apps/gateway/src/repositories/wallpaper.repository.ts
@@ -1,6 +1,7 @@
 import { Attributes, recordCounter, recordHistogram, withSpan } from '@wallpaperdb/core/telemetry';
 import { inject, singleton } from 'tsyringe';
 import { OpenSearchConnection } from '../connections/opensearch.js';
+import type { CursorValue } from '../services/cursor.service.js';
 import { IndexManagerService } from '../services/index-manager.service.js';
 import { GatewayAttributes } from '../telemetry/attributes.js';
 
@@ -19,6 +20,11 @@ export interface WallpaperDocument {
   variants: Variant[];
   uploadedAt: string;
   updatedAt: string;
+}
+
+interface SearchHit {
+  _source: WallpaperDocument;
+  sort?: unknown[];
 }
 
 /**
@@ -158,12 +164,13 @@ export class WallpaperRepository {
       aspectRatio?: number;
       format?: string;
     };
-    from?: number;
+    searchAfter?: CursorValue[];
     size?: number;
-  }): Promise<{ documents: WallpaperDocument[]; total: number }> {
+    sortOrder?: 'asc' | 'desc';
+  }): Promise<{ documents: WallpaperDocument[]; cursorValues: CursorValue[][]; total: number }> {
     const indexName = this.indexManager.getIndexName();
     const pageSize = params.size ?? 10;
-    const offset = params.from ?? 0;
+    const sortOrder = params.sortOrder ?? 'asc';
 
     return await withSpan(
       'opensearch.search',
@@ -171,12 +178,13 @@ export class WallpaperRepository {
         [GatewayAttributes.OPENSEARCH_INDEX]: indexName,
         [GatewayAttributes.OPENSEARCH_OPERATION]: 'search',
         [GatewayAttributes.SEARCH_PAGE_SIZE]: pageSize,
-        [GatewayAttributes.SEARCH_OFFSET]: offset,
         [GatewayAttributes.SEARCH_FILTER_USER_ID]: params.userId ?? 'none',
         [GatewayAttributes.SEARCH_FILTER_HAS_VARIANT]: params.variantFilters ? 'true' : 'false',
       },
       async (span) => {
         const startTime = Date.now();
+        span.setAttribute('search.cursor.present', params.searchAfter ? 'true' : 'false');
+        span.setAttribute('search.sort.order', sortOrder);
 
         const must: unknown[] = [];
 
@@ -228,22 +236,46 @@ export class WallpaperRepository {
         }
 
         try {
+          const body: {
+            query: {
+              bool: {
+                must: unknown[];
+              };
+            };
+            search_after?: CursorValue[];
+            size: number;
+            sort: Array<{ wallpaperId: 'asc' | 'desc' }>;
+          } = {
+            query: {
+              bool: {
+                must: must.length > 0 ? must : [{ match_all: {} }],
+              },
+            },
+            size: pageSize,
+            sort: [{ wallpaperId: sortOrder }],
+          };
+
+          if (params.searchAfter) {
+            body.search_after = params.searchAfter;
+          }
+
           const result = await this.openSearchConnection.getClient().search({
             index: indexName,
-            body: {
-              query: {
-                bool: {
-                  must: must.length > 0 ? must : [{ match_all: {} }],
-                },
-              },
-              from: offset,
-              size: pageSize,
-            },
+            body,
           });
 
-          const documents = result.body.hits.hits.map(
-            (hit: { _source: WallpaperDocument }) => hit._source
-          );
+          const hits = result.body.hits.hits as SearchHit[];
+          const documents = hits.map((hit) => hit._source);
+          const cursorValues = hits.map((hit) => {
+            if (
+              Array.isArray(hit.sort) &&
+              hit.sort.every((value) => typeof value === 'number' || typeof value === 'string')
+            ) {
+              return hit.sort as CursorValue[];
+            }
+
+            return [hit._source.wallpaperId];
+          });
           const total = result.body.hits.total.value as number;
 
           span.setAttribute(GatewayAttributes.SEARCH_TOTAL_RESULTS, total);
@@ -253,7 +285,7 @@ export class WallpaperRepository {
             [GatewayAttributes.OPENSEARCH_INDEX]: indexName,
           });
 
-          return { documents, total };
+          return { documents, cursorValues, total };
         } catch (error) {
           this.recordOperationMetrics('search', false, startTime);
           throw error;

--- a/apps/gateway/src/services/cursor.service.ts
+++ b/apps/gateway/src/services/cursor.service.ts
@@ -3,6 +3,8 @@ import { inject, singleton } from 'tsyringe';
 import type { Config } from '../config.js';
 import { InvalidCursorError } from '../errors/graphql-errors.js';
 
+export type CursorValue = number | string;
+
 /**
  * Service for encoding/decoding secure cursors with HMAC signatures
  */
@@ -15,10 +17,10 @@ export class CursorService {
   }
 
   /**
-   * Encode offset into opaque cursor with HMAC signature
+   * Encode search_after values into opaque cursor with HMAC signature
    */
-  encode(offset: number): string {
-    const payload = JSON.stringify({ offset, timestamp: Date.now() });
+  encode(values: CursorValue[]): string {
+    const payload = JSON.stringify({ values, timestamp: Date.now() });
     const signature = crypto.createHmac('sha256', this.secret).update(payload).digest('hex');
 
     const cursor = Buffer.from(
@@ -34,7 +36,7 @@ export class CursorService {
   /**
    * Decode cursor and verify signature
    */
-  decode(cursor: string): number {
+  decode(cursor: string): CursorValue[] {
     try {
       const decoded = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf-8'));
 
@@ -50,7 +52,7 @@ export class CursorService {
         throw new Error('Invalid cursor signature');
       }
 
-      const { offset, timestamp } = JSON.parse(payload);
+      const { values, timestamp } = JSON.parse(payload);
 
       // Check cursor age
       const age = Date.now() - timestamp;
@@ -58,7 +60,14 @@ export class CursorService {
         throw new Error('Cursor expired');
       }
 
-      return offset;
+      if (
+        !Array.isArray(values) ||
+        values.some((value) => typeof value !== 'number' && typeof value !== 'string')
+      ) {
+        throw new Error('Invalid cursor payload');
+      }
+
+      return values;
     } catch (error) {
       throw new InvalidCursorError(
         error instanceof Error ? error.message : 'Invalid or expired cursor'

--- a/apps/gateway/test/cursor.service.test.ts
+++ b/apps/gateway/test/cursor.service.test.ts
@@ -1,0 +1,35 @@
+import crypto from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { CursorService } from '../src/services/cursor.service.js';
+
+describe('CursorService', () => {
+  const config = {
+    cursorSecret: 'test-secret-that-is-definitely-long-enough',
+    cursorExpirationMs: 60_000,
+  } as const;
+
+  it('encodes and decodes search_after values', () => {
+    const service = new CursorService(config as never);
+    const values = [42, 'wlpr_cursor_001'];
+
+    const cursor = service.encode(values);
+    const decodedCursor = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf-8'));
+    const payload = JSON.parse(decodedCursor.payload);
+
+    expect(payload).toMatchObject({ values });
+    expect(payload).not.toHaveProperty('offset');
+    expect(service.decode(cursor)).toEqual(values);
+  });
+
+  it('rejects expired cursors with search_after values', () => {
+    const service = new CursorService(config as never);
+    const payload = JSON.stringify({
+      values: ['wlpr_cursor_002'],
+      timestamp: Date.now() - config.cursorExpirationMs - 1,
+    });
+    const signature = crypto.createHmac('sha256', config.cursorSecret).update(payload).digest('hex');
+    const cursor = Buffer.from(JSON.stringify({ payload, signature })).toString('base64url');
+
+    expect(() => service.decode(cursor)).toThrow(/expired/i);
+  });
+});

--- a/apps/gateway/test/graphql-security.test.ts
+++ b/apps/gateway/test/graphql-security.test.ts
@@ -543,7 +543,7 @@ describe('GraphQL Security', () => {
     it('should reject expired cursors', async () => {
       // Manually create expired cursor by encoding with past timestamp
       const expiredPayload = JSON.stringify({
-        offset: 10,
+        values: ['wlpr_expired_cursor'],
         timestamp: Date.now() - 8 * 24 * 60 * 60 * 1000, // 8 days ago (past 7 day expiration)
       });
 

--- a/apps/gateway/test/graphql.test.ts
+++ b/apps/gateway/test/graphql.test.ts
@@ -247,6 +247,11 @@ describe("GraphQL API Integration", () => {
             expect(response1.statusCode).toBe(200);
             const result1 = JSON.parse(response1.body);
             expect(result1.data.searchWallpapers.edges).toHaveLength(2);
+            expect(
+                result1.data.searchWallpapers.edges.map(
+                    (edge: { node: { wallpaperId: string } }) => edge.node.wallpaperId,
+                ),
+            ).toEqual(["wlpr_gql_page_0", "wlpr_gql_page_1"]);
             expect(result1.data.searchWallpapers.pageInfo.hasNextPage).toBe(true);
 
             const cursor = result1.data.searchWallpapers.pageInfo.endCursor;
@@ -284,6 +289,85 @@ describe("GraphQL API Integration", () => {
             expect(response2.statusCode).toBe(200);
             const result2 = JSON.parse(response2.body);
             expect(result2.data.searchWallpapers.edges).toHaveLength(2);
+            expect(
+                result2.data.searchWallpapers.edges.map(
+                    (edge: { node: { wallpaperId: string } }) => edge.node.wallpaperId,
+                ),
+            ).toEqual(["wlpr_gql_page_2", "wlpr_gql_page_3"]);
+            expect(result2.data.searchWallpapers.pageInfo.hasPreviousPage).toBe(true);
+        });
+
+        it("should support pagination with last/before", async () => {
+            for (let i = 0; i < 5; i++) {
+                await container.resolve(WallpaperRepository).upsert({
+                    wallpaperId: `wlpr_gql_back_${i}`,
+                    userId: "user_gql_backward_pagination",
+                    variants: [],
+                    uploadedAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                });
+            }
+
+            const query1 = `
+				query {
+					searchWallpapers(filter: { userId: "user_gql_backward_pagination" }, first: 4) {
+						pageInfo {
+							endCursor
+						}
+					}
+				}
+			`;
+
+            const response1 = await tester.getApp().inject({
+                method: "POST",
+                url: "/graphql",
+                headers: {
+                    "content-type": "application/json",
+                },
+                payload: JSON.stringify({ query: query1 }),
+            });
+
+            expect(response1.statusCode).toBe(200);
+            const result1 = JSON.parse(response1.body);
+            const cursor = result1.data.searchWallpapers.pageInfo.endCursor;
+
+            const query2 = `
+				query {
+					searchWallpapers(
+						filter: { userId: "user_gql_backward_pagination" }
+						last: 2
+						before: "${cursor}"
+					) {
+						edges {
+							node {
+								wallpaperId
+							}
+						}
+						pageInfo {
+							hasNextPage
+							hasPreviousPage
+						}
+					}
+				}
+			`;
+
+            const response2 = await tester.getApp().inject({
+                method: "POST",
+                url: "/graphql",
+                headers: {
+                    "content-type": "application/json",
+                },
+                payload: JSON.stringify({ query: query2 }),
+            });
+
+            expect(response2.statusCode).toBe(200);
+            const result2 = JSON.parse(response2.body);
+            expect(
+                result2.data.searchWallpapers.edges.map(
+                    (edge: { node: { wallpaperId: string } }) => edge.node.wallpaperId,
+                ),
+            ).toEqual(["wlpr_gql_back_1", "wlpr_gql_back_2"]);
+            expect(result2.data.searchWallpapers.pageInfo.hasNextPage).toBe(true);
             expect(result2.data.searchWallpapers.pageInfo.hasPreviousPage).toBe(true);
         });
 

--- a/apps/gateway/test/opensearch.test.ts
+++ b/apps/gateway/test/opensearch.test.ts
@@ -211,5 +211,39 @@ describe("OpenSearch Integration", () => {
             expect(result.total).toBe(0);
             expect(result.documents).toEqual([]);
         });
+
+        it("should paginate deterministically with search_after", async () => {
+            for (let i = 0; i < 4; i++) {
+                await repository.upsert({
+                    wallpaperId: `wlpr_test_page_${i}`,
+                    userId: "user_search_after",
+                    variants: [],
+                    uploadedAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                });
+            }
+
+            const firstPage = await repository.search({
+                userId: "user_search_after",
+                size: 2,
+            });
+
+            expect(firstPage.documents.map((doc) => doc.wallpaperId)).toEqual([
+                "wlpr_test_page_0",
+                "wlpr_test_page_1",
+            ]);
+            expect(firstPage.cursorValues.at(-1)).toEqual(["wlpr_test_page_1"]);
+
+            const secondPage = await repository.search({
+                userId: "user_search_after",
+                searchAfter: firstPage.cursorValues.at(-1),
+                size: 2,
+            });
+
+            expect(secondPage.documents.map((doc) => doc.wallpaperId)).toEqual([
+                "wlpr_test_page_2",
+                "wlpr_test_page_3",
+            ]);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- switch wallpaper pagination from offset-based cursors to OpenSearch `search_after` cursor values
- add forward and backward GraphQL pagination support using encoded sort values
- return cursor values from the repository and update cursor signing/validation for array payloads
- add integration and unit coverage for cursor encoding, deterministic pagination, and `last`/`before` behavior

## Testing
- Added `apps/gateway/test/cursor.service.test.ts` for encoding/decoding and expired cursor validation
- Added GraphQL integration checks in `apps/gateway/test/graphql.test.ts` for forward pagination ordering and `last`/`before` pagination
- Added OpenSearch integration checks in `apps/gateway/test/opensearch.test.ts` for deterministic `search_after` pagination
- Updated `apps/gateway/test/graphql-security.test.ts` to validate expired signed cursors with search-after payloads