### PR TITLE
Index extracted wallpaper colors in gateway

### DIFF
--- a/apps/gateway/src/app.ts
+++ b/apps/gateway/src/app.ts
@@ -9,6 +9,7 @@ import type { Config } from './config.js';
 import { NatsConnectionManager } from './connections/nats.js';
 import { OpenSearchConnection } from './connections/opensearch.js';
 import { RedisConnection } from './connections/redis.js';
+import { WallpaperColorsExtractedConsumer } from './consumers/wallpaper-colors-extracted.consumer.js';
 import { WallpaperUploadedConsumer } from './consumers/wallpaper-uploaded.consumer.js';
 import { WallpaperVariantAvailableConsumer } from './consumers/wallpaper-variant-available.consumer.js';
 import { RateLimitExceededError } from './errors/graphql-errors.js';
@@ -233,6 +234,10 @@ export async function createApp(
     await uploadedConsumer.start();
     fastify.log.info('WallpaperUploadedConsumer started');
 
+    const colorsConsumer = container.resolve(WallpaperColorsExtractedConsumer);
+    await colorsConsumer.start();
+    fastify.log.info('WallpaperColorsExtractedConsumer started');
+
     // Mark connections as initialized
     fastify.connectionsState.connectionsInitialized = true;
   } catch (error) {
@@ -260,6 +265,9 @@ export async function createApp(
 
     const variantConsumer = container.resolve(WallpaperVariantAvailableConsumer);
     await variantConsumer.stop();
+
+    const colorsConsumer = container.resolve(WallpaperColorsExtractedConsumer);
+    await colorsConsumer.stop();
     fastify.log.info('Event consumers stopped');
 
     fastify.log.info('Closing NATS connection...');

--- a/apps/gateway/src/consumers/wallpaper-colors-extracted.consumer.ts
+++ b/apps/gateway/src/consumers/wallpaper-colors-extracted.consumer.ts
@@ -1,0 +1,59 @@
+import { Attributes, recordCounter, recordHistogram, withSpan } from '@wallpaperdb/core/telemetry';
+import {
+  BaseEventConsumer,
+  WALLPAPER_COLORS_EXTRACTED_SUBJECT,
+  type WallpaperColorsExtractedEvent,
+  WallpaperColorsExtractedEventSchema,
+} from '@wallpaperdb/events';
+import { inject, singleton } from 'tsyringe';
+import { NatsConnectionManager } from '../connections/nats.js';
+import { WallpaperRepository } from '../repositories/wallpaper.repository.js';
+
+/**
+ * Consumer for wallpaper.colors.extracted events
+ * Adds extracted color data to existing wallpaper documents
+ */
+@singleton()
+export class WallpaperColorsExtractedConsumer extends BaseEventConsumer<
+  typeof WallpaperColorsExtractedEventSchema
+> {
+  protected readonly schema = WallpaperColorsExtractedEventSchema;
+  protected readonly subject = WALLPAPER_COLORS_EXTRACTED_SUBJECT;
+  protected readonly eventType = 'wallpaper.colors.extracted' as const;
+
+  constructor(
+    @inject(NatsConnectionManager) natsConnectionManager: NatsConnectionManager,
+    @inject(WallpaperRepository) private readonly wallpaperRepository: WallpaperRepository
+  ) {
+    super({
+      natsConnectionProvider: () => natsConnectionManager.getClient(),
+      serviceName: 'gateway',
+      streamName: 'WALLPAPER',
+      durableName: 'gateway-wallpaper-colors-extracted',
+      maxRetries: 3,
+      ackWait: 30000,
+    });
+  }
+
+  public async handleEvent(event: WallpaperColorsExtractedEvent): Promise<void> {
+    return await withSpan(
+      'gateway.consumer.handle_wallpaper_colors_extracted',
+      {
+        [Attributes.WALLPAPER_ID]: event.wallpaperId,
+        [Attributes.EVENT_ID]: event.eventId,
+      },
+      async () => {
+        const startTime = Date.now();
+
+        await this.wallpaperRepository.addColorData(event.wallpaperId, {
+          colorHistogram: event.colorHistogram,
+          colorSpace: event.colorSpace,
+        });
+
+        const durationMs = Date.now() - startTime;
+        recordCounter('gateway.consumer.color_data_added.total', 1);
+        recordHistogram('gateway.consumer.color_data_add_duration_ms', durationMs);
+      }
+    );
+  }
+}

--- a/apps/gateway/src/opensearch/mappings.ts
+++ b/apps/gateway/src/opensearch/mappings.ts
@@ -11,6 +11,11 @@
  * - format enum for easy filtering by image type
  */
 export const wallpapersIndexMapping = {
+  settings: {
+    index: {
+      knn: true,
+    },
+  },
   properties: {
     wallpaperId: { type: 'keyword' },
     userId: { type: 'keyword' },
@@ -27,6 +32,17 @@ export const wallpapersIndexMapping = {
         createdAt: { type: 'date' },
       },
     },
+
+    colorHistogram: {
+      type: 'knn_vector',
+      dimension: 64,
+      method: {
+        name: 'hnsw',
+        engine: 'lucene',
+        space_type: 'cosinesimil',
+      },
+    },
+    colorSpace: { type: 'keyword' },
 
     // Timestamps
     uploadedAt: { type: 'date' },

--- a/apps/gateway/src/repositories/wallpaper.repository.ts
+++ b/apps/gateway/src/repositories/wallpaper.repository.ts
@@ -18,6 +18,8 @@ export interface WallpaperDocument {
   wallpaperId: string;
   userId: string;
   variants: Variant[];
+  colorHistogram?: number[];
+  colorSpace?: string;
   uploadedAt: string;
   updatedAt: string;
 }
@@ -107,6 +109,55 @@ export class WallpaperRepository {
           this.recordOperationMetrics('add_variant', true, startTime);
         } catch (error) {
           this.recordOperationMetrics('add_variant', false, startTime);
+          throw error;
+        }
+      }
+    );
+  }
+
+  /**
+   * Add extracted color data to a wallpaper document
+   */
+  async addColorData(
+    wallpaperId: string,
+    colorData: { colorHistogram: number[]; colorSpace: string }
+  ): Promise<void> {
+    const indexName = this.indexManager.getIndexName();
+    return await withSpan(
+      'opensearch.add_color_data',
+      {
+        [GatewayAttributes.OPENSEARCH_INDEX]: indexName,
+        [GatewayAttributes.OPENSEARCH_OPERATION]: 'add_color_data',
+        [GatewayAttributes.OPENSEARCH_DOC_ID]: wallpaperId,
+        [Attributes.WALLPAPER_ID]: wallpaperId,
+      },
+      async () => {
+        const startTime = Date.now();
+        try {
+          await this.openSearchConnection.getClient().update({
+            index: indexName,
+            id: wallpaperId,
+            body: {
+              script: {
+                source: `
+                  ctx._source.colorHistogram = params.colorHistogram;
+                  ctx._source.colorSpace = params.colorSpace;
+                  ctx._source.updatedAt = params.updatedAt;
+                `,
+                params: {
+                  colorHistogram: colorData.colorHistogram,
+                  colorSpace: colorData.colorSpace,
+                  updatedAt: new Date().toISOString(),
+                },
+              },
+            },
+            refresh: true,
+            retry_on_conflict: 3,
+          });
+
+          this.recordOperationMetrics('add_color_data', true, startTime);
+        } catch (error) {
+          this.recordOperationMetrics('add_color_data', false, startTime);
           throw error;
         }
       }

--- a/apps/gateway/src/services/index-manager.service.ts
+++ b/apps/gateway/src/services/index-manager.service.ts
@@ -41,7 +41,10 @@ export class IndexManagerService {
         await client.indices.create({
           index: this.indexName,
           body: {
-            mappings: wallpapersIndexMapping,
+            settings: wallpapersIndexMapping.settings,
+            mappings: {
+              properties: wallpapersIndexMapping.properties,
+            },
           },
         });
 

--- a/apps/gateway/test/event-consumers.test.ts
+++ b/apps/gateway/test/event-consumers.test.ts
@@ -1,7 +1,9 @@
 import "reflect-metadata";
 import {
+    WALLPAPER_COLORS_EXTRACTED_SUBJECT,
     WALLPAPER_UPLOADED_SUBJECT,
     WALLPAPER_VARIANT_AVAILABLE_SUBJECT,
+    type WallpaperColorsExtractedEvent,
     type WallpaperUploadedEvent,
     type WallpaperVariantAvailableEvent,
 } from "@wallpaperdb/events";
@@ -219,6 +221,85 @@ describe("Event Consumers Integration", () => {
             expect(doc?.variants).toHaveLength(2);
             expect(doc?.variants[0].format).toBe("image/webp");
             expect(doc?.variants[1].format).toBe("image/png");
+        });
+    });
+
+    describe("WallpaperColorsExtractedConsumer", () => {
+        it("should add color data to an existing wallpaper document without clobbering other fields", async () => {
+            const uploadEvent: WallpaperUploadedEvent = {
+                eventId: "evt_008",
+                eventType: "wallpaper.uploaded",
+                timestamp: new Date().toISOString(),
+                wallpaper: {
+                    id: "wlpr_consumer_005",
+                    userId: "user_005",
+                    fileType: "image",
+                    mimeType: "image/jpeg",
+                    fileSizeBytes: 1024000,
+                    width: 1920,
+                    height: 1080,
+                    aspectRatio: 1920 / 1080,
+                    storageKey: "wlpr_consumer_005/original.jpg",
+                    storageBucket: "wallpapers",
+                    originalFilename: "test.jpg",
+                    uploadedAt: new Date().toISOString(),
+                },
+            };
+
+            const variantEvent: WallpaperVariantAvailableEvent = {
+                eventId: "evt_009",
+                eventType: "wallpaper.variant.available",
+                timestamp: new Date().toISOString(),
+                variant: {
+                    wallpaperId: "wlpr_consumer_005",
+                    width: 1920,
+                    height: 1080,
+                    aspectRatio: 1920 / 1080,
+                    format: "image/jpeg",
+                    fileSizeBytes: 500000,
+                    createdAt: new Date().toISOString(),
+                },
+            };
+
+            const colorHistogram = Array.from({ length: 64 }, (_, index) =>
+                index === 0 ? 1 : 0,
+            );
+
+            const colorsEvent: WallpaperColorsExtractedEvent = {
+                eventId: "evt_010",
+                eventType: "wallpaper.colors.extracted",
+                timestamp: new Date().toISOString(),
+                wallpaperId: "wlpr_consumer_005",
+                colorHistogram,
+                colorSpace: "hsv",
+            };
+
+            await tester.nats.publishEvent(WALLPAPER_UPLOADED_SUBJECT, uploadEvent);
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            await tester.nats.publishEvent(
+                WALLPAPER_VARIANT_AVAILABLE_SUBJECT,
+                variantEvent,
+            );
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            await tester.nats.publishEvent(
+                WALLPAPER_COLORS_EXTRACTED_SUBJECT,
+                colorsEvent,
+            );
+            await tester.nats.publishEvent(
+                WALLPAPER_COLORS_EXTRACTED_SUBJECT,
+                colorsEvent,
+            );
+
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            const doc = await container.resolve(WallpaperRepository).findById("wlpr_consumer_005");
+            expect(doc).not.toBeNull();
+            expect(doc?.variants).toHaveLength(1);
+            expect(doc?.variants[0]?.format).toBe("image/jpeg");
+            expect(doc?.colorHistogram).toEqual(colorHistogram);
+            expect(doc?.colorSpace).toBe("hsv");
         });
     });
 });

--- a/apps/gateway/test/opensearch.test.ts
+++ b/apps/gateway/test/opensearch.test.ts
@@ -24,6 +24,28 @@ describe("OpenSearch Integration", () => {
 
             expect(exists.body).toBe(true);
         });
+
+        it("should enable kNN and map color fields on the wallpapers index", async () => {
+            const index = await client.indices.get({
+                index: "wallpapers",
+            });
+
+            const wallpaperIndex = index.body.wallpapers;
+
+            expect(wallpaperIndex.settings.index.knn).toBe("true");
+            expect(wallpaperIndex.mappings.properties.colorHistogram).toMatchObject({
+                type: "knn_vector",
+                dimension: 64,
+                method: {
+                    name: "hnsw",
+                    engine: "lucene",
+                    space_type: "cosinesimil",
+                },
+            });
+            expect(wallpaperIndex.mappings.properties.colorSpace).toEqual({
+                type: "keyword",
+            });
+        });
     });
 
     describe("WallpaperRepository", () => {


### PR DESCRIPTION
## Summary
- add a `WallpaperColorsExtractedConsumer` in `apps/gateway` to process `wallpaper.colors.extracted` events
- store extracted color histogram and color space on existing wallpaper documents without overwriting other fields
- enable kNN on the wallpapers OpenSearch index and add `colorHistogram`/`colorSpace` mappings for vector search support
- start and stop the new consumer with the gateway application lifecycle
- extend integration coverage for the new consumer flow and OpenSearch index mapping

## Testing
- `apps/gateway/test/event-consumers.test.ts`: verifies color extraction events update an existing wallpaper document while preserving variants and other fields
- `apps/gateway/test/opensearch.test.ts`: verifies the wallpapers index enables kNN and includes the expected color field mappings
- Not run