### PR TITLE
Add browse page format filters

### DIFF
--- a/apps/web/src/components/browse-filter-panel-context.tsx
+++ b/apps/web/src/components/browse-filter-panel-context.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useMemo, useState, type ReactNode } from 'react';
+
+interface BrowseFilterPanelState {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  toggle: () => void;
+}
+
+const BrowseFilterPanelContext = createContext<BrowseFilterPanelState | null>(null);
+
+export function BrowseFilterPanelProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const value = useMemo(
+    () => ({
+      isOpen,
+      setIsOpen,
+      toggle: () => setIsOpen((current) => !current),
+    }),
+    [isOpen]
+  );
+
+  return (
+    <BrowseFilterPanelContext.Provider value={value}>{children}</BrowseFilterPanelContext.Provider>
+  );
+}
+
+export function useBrowseFilterPanel() {
+  const context = useContext(BrowseFilterPanelContext);
+
+  if (!context) {
+    throw new Error('useBrowseFilterPanel must be used within BrowseFilterPanelProvider');
+  }
+
+  return context;
+}

--- a/apps/web/src/components/search-bar.tsx
+++ b/apps/web/src/components/search-bar.tsx
@@ -1,5 +1,6 @@
-import { Search } from 'lucide-react';
+import { Search, SlidersHorizontal } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
 import { InputGroup, InputGroupAddon, InputGroupInput } from '@/components/ui/input-group';
 import { Kbd } from '@/components/ui/kbd';
 
@@ -13,7 +14,17 @@ function useIsMac() {
   return isMac;
 }
 
-export function SearchBar() {
+interface SearchBarProps {
+  showFilterToggle?: boolean;
+  isFilterPanelOpen?: boolean;
+  onToggleFilters?: () => void;
+}
+
+export function SearchBar({
+  showFilterToggle = false,
+  isFilterPanelOpen = false,
+  onToggleFilters,
+}: SearchBarProps = {}) {
   const inputRef = useRef<HTMLInputElement>(null);
   const isMac = useIsMac();
 
@@ -37,6 +48,20 @@ export function SearchBar() {
       </InputGroupAddon>
       <InputGroupInput ref={inputRef} type="search" placeholder="Search wallpapers..." />
       <InputGroupAddon align="inline-end" className="hidden sm:flex">
+        {showFilterToggle && onToggleFilters ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label="Toggle filters"
+            aria-pressed={isFilterPanelOpen}
+            onClick={onToggleFilters}
+            className="h-7 px-2"
+          >
+            <SlidersHorizontal className="h-4 w-4" />
+            <span className="hidden md:inline">Filters</span>
+          </Button>
+        ) : null}
         {isMac ? <Kbd>⌘</Kbd> : <Kbd>Ctrl</Kbd>}
         <Kbd>K</Kbd>
       </InputGroupAddon>

--- a/apps/web/src/lib/browse-filters.ts
+++ b/apps/web/src/lib/browse-filters.ts
@@ -1,0 +1,48 @@
+import type { WallpaperFilter } from '@/lib/graphql/types';
+
+export const BROWSE_FORMAT_OPTIONS = [
+  { value: 'any', label: 'Any' },
+  { value: 'jpeg', label: 'JPEG', mimeType: 'image/jpeg' },
+  { value: 'png', label: 'PNG', mimeType: 'image/png' },
+  { value: 'webp', label: 'WebP', mimeType: 'image/webp' },
+] as const;
+
+export type BrowseFormatValue = Exclude<(typeof BROWSE_FORMAT_OPTIONS)[number]['value'], 'any'>;
+
+export interface BrowseSearchState {
+  after?: string;
+  format?: BrowseFormatValue;
+}
+
+export function parseBrowseSearch(search: Record<string, unknown>): BrowseSearchState {
+  return {
+    after: typeof search.after === 'string' ? search.after : undefined,
+    format: isBrowseFormatValue(search.format) ? search.format : undefined,
+  };
+}
+
+export function buildWallpaperFilter(format?: BrowseFormatValue): WallpaperFilter | undefined {
+  const selectedFormat = BROWSE_FORMAT_OPTIONS.find((option) => option.value === format);
+
+  if (!selectedFormat || !('mimeType' in selectedFormat)) {
+    return undefined;
+  }
+
+  return {
+    variants: {
+      format: selectedFormat.mimeType,
+    },
+  };
+}
+
+export function getFormatBadgeLabel(format: BrowseFormatValue): string {
+  return `Format: ${getFormatLabel(format)}`;
+}
+
+export function getFormatLabel(format: BrowseFormatValue): string {
+  return BROWSE_FORMAT_OPTIONS.find((option) => option.value === format)?.label ?? format;
+}
+
+function isBrowseFormatValue(value: unknown): value is BrowseFormatValue {
+  return value === 'jpeg' || value === 'png' || value === 'webp';
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -3,6 +3,10 @@ import { createRootRouteWithContext, Link, Outlet, useRouterState } from '@tanst
 import { TanStackRouterDevtools } from '@tanstack/router-devtools';
 import { Image, X } from 'lucide-react';
 import { AppSidebar } from '@/components/app-sidebar';
+import {
+  BrowseFilterPanelProvider,
+  useBrowseFilterPanel,
+} from '@/components/browse-filter-panel-context';
 import { HeaderLayout } from '@/components/header-layout';
 import { SearchBar } from '@/components/search-bar';
 import { Button } from '@/components/ui/button';
@@ -25,6 +29,26 @@ function RootLayout() {
   // router state, so this check works correctly regardless of sub-path deployment.
   // e.g. at basepath="/web", navigating to /web/wallpapers/123 → pathname is /wallpapers/123.
   const isWallpaperDetailsPage = routerState.location.pathname.startsWith('/wallpapers/');
+  const isBrowsePage = routerState.location.pathname === '/';
+
+  return (
+    <BrowseFilterPanelProvider>
+      <RootLayoutContent
+        isBrowsePage={isBrowsePage}
+        isWallpaperDetailsPage={isWallpaperDetailsPage}
+      />
+    </BrowseFilterPanelProvider>
+  );
+}
+
+function RootLayoutContent({
+  isBrowsePage,
+  isWallpaperDetailsPage,
+}: {
+  isBrowsePage: boolean;
+  isWallpaperDetailsPage: boolean;
+}) {
+  const { isOpen, toggle } = useBrowseFilterPanel();
 
   const handleClose = () => {
     // Close the current tab/window
@@ -48,7 +72,13 @@ function RootLayout() {
                 </Link>
               </>
             }
-            center={<SearchBar />}
+            center={
+              <SearchBar
+                showFilterToggle={isBrowsePage}
+                isFilterPanelOpen={isOpen}
+                onToggleFilters={isBrowsePage ? toggle : undefined}
+              />
+            }
             right={
               isWallpaperDetailsPage ? (
                 <>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,33 +1,56 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { AlertCircle, ArrowLeft, ImageOff, Upload } from 'lucide-react';
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
+import { useBrowseFilterPanel } from '@/components/browse-filter-panel-context';
 import { WallpaperGridSkeleton } from '@/components/grid';
 import { LoadMoreTrigger } from '@/components/LoadMoreTrigger';
+import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { WallpaperGrid } from '@/components/WallpaperGrid';
 import { useWallpaperInfiniteQuery } from '@/hooks/useWallpaperInfiniteQuery';
+import {
+  BROWSE_FORMAT_OPTIONS,
+  buildWallpaperFilter,
+  getFormatBadgeLabel,
+  parseBrowseSearch,
+  type BrowseFormatValue,
+} from '@/lib/browse-filters';
 
 export const Route = createFileRoute('/')({
   component: HomePage,
-  validateSearch: (search: Record<string, unknown>): { after?: string } => ({
-    after: typeof search.after === 'string' ? search.after : undefined,
-  }),
+  validateSearch: parseBrowseSearch,
 });
 
-function HomePage() {
-  const { after } = Route.useSearch();
-  const initialCursorRef = useRef(after);
+export function HomePage() {
+  const { after, format } = Route.useSearch();
+  const navigate = useNavigate();
+  const { isOpen } = useBrowseFilterPanel();
 
   const { data, isLoading, isFetchingNextPage, error, hasNextPage, fetchNextPage } =
     useWallpaperInfiniteQuery({
-      initialCursor: initialCursorRef.current ?? null,
+      initialCursor: after ?? null,
+      filter: buildWallpaperFilter(format),
     });
 
   const handleLoadMore = useCallback(() => {
     fetchNextPage();
   }, [fetchNextPage]);
+
+  const handleFormatChange = useCallback(
+    (nextFormat?: BrowseFormatValue) => {
+      void navigate({
+        to: '/',
+        search: (previous: { after?: string; format?: BrowseFormatValue }) => ({
+          ...previous,
+          after: undefined,
+          format: nextFormat,
+        }),
+      });
+    },
+    [navigate]
+  );
 
   if (isLoading) {
     return <LoadingState />;
@@ -40,11 +63,25 @@ function HomePage() {
   const wallpapers = data?.pages.flatMap((page) => page.edges.map((edge) => edge.node)) ?? [];
 
   if (wallpapers.length === 0) {
-    return <EmptyState hasCursor={!!initialCursorRef.current} />;
+    return (
+      <div>
+        <BrowseFilterPanel
+          isOpen={isOpen}
+          selectedFormat={format}
+          onFormatChange={handleFormatChange}
+        />
+        <EmptyState hasCursor={!!after} />
+      </div>
+    );
   }
 
   return (
     <div>
+      <BrowseFilterPanel
+        isOpen={isOpen}
+        selectedFormat={format}
+        onFormatChange={handleFormatChange}
+      />
       <WallpaperGrid wallpapers={wallpapers} isLoadingMore={isFetchingNextPage} />
       <LoadMoreTrigger
         onLoadMore={handleLoadMore}
@@ -52,6 +89,59 @@ function HomePage() {
         isLoading={isFetchingNextPage}
       />
     </div>
+  );
+}
+
+function BrowseFilterPanel({
+  isOpen,
+  selectedFormat,
+  onFormatChange,
+}: {
+  isOpen: boolean;
+  selectedFormat?: BrowseFormatValue;
+  onFormatChange: (format?: BrowseFormatValue) => void;
+}) {
+  return (
+    <section className="border-b bg-muted/20 px-4 py-3">
+      <div className="mx-auto flex max-w-6xl flex-col gap-3">
+        {isOpen ? (
+          <div className="flex flex-col gap-2">
+            <div>
+              <p className="text-sm font-medium text-foreground">Format</p>
+              <p className="text-muted-foreground text-xs">
+                Limit results to a specific wallpaper file type.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {BROWSE_FORMAT_OPTIONS.map((option) => {
+                const isSelected = option.value === (selectedFormat ?? 'any');
+
+                return (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant={isSelected ? 'secondary' : 'outline'}
+                    size="sm"
+                    onClick={() =>
+                      onFormatChange(option.value === 'any' ? undefined : option.value)
+                    }
+                    aria-pressed={isSelected}
+                  >
+                    {option.label}
+                  </Button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+
+        {!isOpen && selectedFormat ? (
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="outline">{getFormatBadgeLabel(selectedFormat)}</Badge>
+          </div>
+        ) : null}
+      </div>
+    </section>
   );
 }
 

--- a/apps/web/test/components/search-bar.test.tsx
+++ b/apps/web/test/components/search-bar.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { SearchBar } from '@/components/search-bar';
+
+describe('SearchBar', () => {
+  it('renders a filter toggle button when requested', async () => {
+    const user = userEvent.setup();
+    const onToggleFilters = vi.fn();
+
+    render(
+      <SearchBar showFilterToggle={true} isFilterPanelOpen={false} onToggleFilters={onToggleFilters} />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /toggle filters/i }));
+
+    expect(onToggleFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the filter toggle away from the browse page', () => {
+    render(<SearchBar />);
+
+    expect(screen.queryByRole('button', { name: /toggle filters/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/test/lib/browse-filters.test.ts
+++ b/apps/web/test/lib/browse-filters.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildWallpaperFilter,
+  getFormatBadgeLabel,
+  parseBrowseSearch,
+} from '@/lib/browse-filters';
+
+describe('browse filters', () => {
+  it('keeps only supported format values from route search', () => {
+    expect(parseBrowseSearch({ after: 'cursor_123', format: 'png' })).toEqual({
+      after: 'cursor_123',
+      format: 'png',
+    });
+
+    expect(parseBrowseSearch({ after: 'cursor_123', format: 'gif' })).toEqual({
+      after: 'cursor_123',
+      format: undefined,
+    });
+  });
+
+  it('maps a selected format to the wallpaper query filter', () => {
+    expect(buildWallpaperFilter(undefined)).toBeUndefined();
+    expect(buildWallpaperFilter('jpeg')).toEqual({ variants: { format: 'image/jpeg' } });
+    expect(buildWallpaperFilter('png')).toEqual({ variants: { format: 'image/png' } });
+    expect(buildWallpaperFilter('webp')).toEqual({ variants: { format: 'image/webp' } });
+  });
+
+  it('formats active filter badges using user-facing labels', () => {
+    expect(getFormatBadgeLabel('jpeg')).toBe('Format: JPEG');
+    expect(getFormatBadgeLabel('png')).toBe('Format: PNG');
+    expect(getFormatBadgeLabel('webp')).toBe('Format: WebP');
+  });
+});

--- a/apps/web/test/routes/index.test.tsx
+++ b/apps/web/test/routes/index.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+const mockUseSearch = vi.fn(() => ({}));
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (config: Record<string, unknown>) => ({
+    ...config,
+    useSearch: () => mockUseSearch(),
+  }),
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/hooks/useWallpaperInfiniteQuery', () => ({
+  useWallpaperInfiniteQuery: vi.fn(),
+}));
+
+vi.mock('@/components/browse-filter-panel-context', () => ({
+  useBrowseFilterPanel: vi.fn(),
+}));
+
+vi.mock('@/components/WallpaperGrid', () => ({
+  WallpaperGrid: () => <div data-testid="wallpaper-grid" />,
+}));
+
+vi.mock('@/components/LoadMoreTrigger', () => ({
+  LoadMoreTrigger: () => null,
+}));
+
+vi.mock('@/components/grid', () => ({
+  WallpaperGridSkeleton: () => <div data-testid="wallpaper-grid-skeleton" />,
+}));
+
+import { useBrowseFilterPanel } from '@/components/browse-filter-panel-context';
+import { useWallpaperInfiniteQuery } from '@/hooks/useWallpaperInfiniteQuery';
+import { HomePage } from '@/routes/index';
+
+describe('HomePage browse filters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSearch.mockReturnValue({ after: undefined, format: undefined });
+    (useBrowseFilterPanel as Mock).mockReturnValue({
+      isOpen: false,
+      setIsOpen: vi.fn(),
+      toggle: vi.fn(),
+    });
+    (useWallpaperInfiniteQuery as Mock).mockReturnValue({
+      data: {
+        pages: [
+          {
+            edges: [
+              {
+                node: {
+                  wallpaperId: 'wlpr_123',
+                  userId: 'user_1',
+                  variants: [
+                    {
+                      width: 1920,
+                      height: 1080,
+                      aspectRatio: 1.78,
+                      format: 'image/png',
+                      fileSizeBytes: 100,
+                      createdAt: '2025-01-01T00:00:00.000Z',
+                      url: 'https://example.com/wallpaper.png',
+                    },
+                  ],
+                  uploadedAt: '2025-01-01T00:00:00.000Z',
+                  updatedAt: '2025-01-01T00:00:00.000Z',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+      isFetchingNextPage: false,
+      error: null,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+    });
+  });
+
+  it('passes the selected URL-backed format into wallpaper search', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, format: 'png' });
+
+    render(<HomePage />);
+
+    expect(useWallpaperInfiniteQuery).toHaveBeenCalledWith({
+      filter: { variants: { format: 'image/png' } },
+      initialCursor: null,
+    });
+  });
+
+  it('shows the active format as a neutral badge when the panel is collapsed', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, format: 'png' });
+
+    render(<HomePage />);
+
+    expect(screen.getByText('Format: PNG')).toBeInTheDocument();
+    expect(screen.queryByText('JPEG')).not.toBeInTheDocument();
+  });
+
+  it('updates the route search state when a format is selected', async () => {
+    const user = userEvent.setup();
+
+    mockUseSearch.mockReturnValue({ after: 'cursor_123', format: undefined });
+    (useBrowseFilterPanel as Mock).mockReturnValue({
+      isOpen: true,
+      setIsOpen: vi.fn(),
+      toggle: vi.fn(),
+    });
+
+    render(<HomePage />);
+
+    await user.click(screen.getByRole('button', { name: 'PNG' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      search: expect.any(Function),
+      to: '/',
+    });
+
+    const navigateCall = mockNavigate.mock.calls[0][0];
+    expect(navigateCall.search({ after: 'cursor_123', format: undefined })).toEqual({
+      after: undefined,
+      format: 'png',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add browse-page filter state and wire a filter toggle into the shared search bar
- support URL-backed wallpaper format filters for `jpeg`, `png`, and `webp`
- show selected format state in the browse UI, including a collapsed badge view
- add tests covering filter parsing, query mapping, search bar toggle behavior, and route updates

## Testing
- Not run
- verified added unit tests cover `parseBrowseSearch`, `buildWallpaperFilter`, and format badge labels
- verified component test covers filter toggle rendering and click handling in `SearchBar`
- verified route test covers passing the selected format into `useWallpaperInfiniteQuery`, showing the collapsed badge, and resetting pagination when selecting a format