### PR TITLE
Add aspect ratio filters to wallpaper browsing

### DIFF
--- a/apps/web/src/lib/browse-filters.ts
+++ b/apps/web/src/lib/browse-filters.ts
@@ -7,30 +7,75 @@ export const BROWSE_FORMAT_OPTIONS = [
   { value: 'webp', label: 'WebP', mimeType: 'image/webp' },
 ] as const;
 
+export const BROWSE_ASPECT_RATIO_OPTIONS = [
+  { value: 'any', label: 'Any' },
+  { value: 'device', label: 'Device' },
+  { value: '16-9', label: '16:9', ratio: 16 / 9 },
+  { value: '16-10', label: '16:10', ratio: 16 / 10 },
+  { value: '4-3', label: '4:3', ratio: 4 / 3 },
+  { value: '9-16', label: '9:16', ratio: 9 / 16 },
+  { value: '1-1', label: '1:1', ratio: 1 },
+  { value: '21-9', label: '21:9', ratio: 21 / 9 },
+] as const;
+
 export type BrowseFormatValue = Exclude<(typeof BROWSE_FORMAT_OPTIONS)[number]['value'], 'any'>;
+export type BrowseAspectRatioValue = Exclude<
+  (typeof BROWSE_ASPECT_RATIO_OPTIONS)[number]['value'],
+  'any'
+>;
+export type BrowseAspectRatioPresetValue = Exclude<BrowseAspectRatioValue, 'device'>;
 
 export interface BrowseSearchState {
   after?: string;
   format?: BrowseFormatValue;
+  aspectRatio?: BrowseAspectRatioValue;
 }
 
 export function parseBrowseSearch(search: Record<string, unknown>): BrowseSearchState {
   return {
     after: typeof search.after === 'string' ? search.after : undefined,
     format: isBrowseFormatValue(search.format) ? search.format : undefined,
+    aspectRatio: isBrowseAspectRatioValue(search.aspectRatio) ? search.aspectRatio : undefined,
   };
 }
 
-export function buildWallpaperFilter(format?: BrowseFormatValue): WallpaperFilter | undefined {
+export function buildWallpaperFilter(
+  format?: BrowseFormatValue,
+  aspectRatio?: number,
+): WallpaperFilter | undefined {
   const selectedFormat = BROWSE_FORMAT_OPTIONS.find((option) => option.value === format);
+  const variants: NonNullable<WallpaperFilter['variants']> = {};
 
-  if (!selectedFormat || !('mimeType' in selectedFormat)) {
+  if (selectedFormat && 'mimeType' in selectedFormat) {
+    variants.format = selectedFormat.mimeType;
+  }
+
+  if (aspectRatio !== undefined) {
+    variants.aspectRatio = aspectRatio;
+  }
+
+  if (Object.keys(variants).length === 0) {
+    return undefined;
+  }
+
+  return {
+    variants,
+  };
+}
+
+export function buildAspectRatioFilter(
+  aspectRatio: BrowseAspectRatioValue | undefined,
+  deviceAspectRatioPreset: BrowseAspectRatioPresetValue,
+): WallpaperFilter | undefined {
+  const resolvedAspectRatio = getAspectRatioFilterValue(aspectRatio, deviceAspectRatioPreset);
+
+  if (resolvedAspectRatio === undefined) {
     return undefined;
   }
 
   return {
     variants: {
-      format: selectedFormat.mimeType,
+      aspectRatio: resolvedAspectRatio,
     },
   };
 }
@@ -39,10 +84,81 @@ export function getFormatBadgeLabel(format: BrowseFormatValue): string {
   return `Format: ${getFormatLabel(format)}`;
 }
 
+export function getAspectRatioBadgeLabel(
+  aspectRatio: BrowseAspectRatioValue,
+  deviceAspectRatioPreset: BrowseAspectRatioPresetValue,
+): string {
+  return `Aspect ratio: ${getAspectRatioLabel(aspectRatio, deviceAspectRatioPreset)}`;
+}
+
 export function getFormatLabel(format: BrowseFormatValue): string {
   return BROWSE_FORMAT_OPTIONS.find((option) => option.value === format)?.label ?? format;
 }
 
+export function getAspectRatioLabel(
+  aspectRatio: BrowseAspectRatioValue,
+  deviceAspectRatioPreset: BrowseAspectRatioPresetValue,
+): string {
+  if (aspectRatio === 'device') {
+    return getDeviceAspectRatioOptionLabel(deviceAspectRatioPreset);
+  }
+
+  return BROWSE_ASPECT_RATIO_OPTIONS.find((option) => option.value === aspectRatio)?.label ?? aspectRatio;
+}
+
+export function getDeviceAspectRatioOptionLabel(
+  deviceAspectRatioPreset: BrowseAspectRatioPresetValue,
+): string {
+  return `Device ${getAspectRatioPresetLabel(deviceAspectRatioPreset)}`;
+}
+
+export function resolveClosestAspectRatioPreset(ratio: number): BrowseAspectRatioPresetValue {
+  let closestPreset: BrowseAspectRatioPresetValue = '16-9';
+  let closestDistance = Number.POSITIVE_INFINITY;
+
+  for (const option of BROWSE_ASPECT_RATIO_OPTIONS) {
+    if (!('ratio' in option)) {
+      continue;
+    }
+
+    const distance = Math.abs(option.ratio - ratio);
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closestPreset = option.value;
+    }
+  }
+
+  return closestPreset;
+}
+
+export function getAspectRatioFilterValue(
+  aspectRatio: BrowseAspectRatioValue | undefined,
+  deviceAspectRatioPreset: BrowseAspectRatioPresetValue,
+): number | undefined {
+  if (!aspectRatio) {
+    return undefined;
+  }
+
+  const preset = aspectRatio === 'device' ? deviceAspectRatioPreset : aspectRatio;
+  return BROWSE_ASPECT_RATIO_OPTIONS.find((option) => option.value === preset && 'ratio' in option)?.ratio;
+}
+
 function isBrowseFormatValue(value: unknown): value is BrowseFormatValue {
   return value === 'jpeg' || value === 'png' || value === 'webp';
+}
+
+function isBrowseAspectRatioValue(value: unknown): value is BrowseAspectRatioValue {
+  return (
+    value === 'device' ||
+    value === '16-9' ||
+    value === '16-10' ||
+    value === '4-3' ||
+    value === '9-16' ||
+    value === '1-1' ||
+    value === '21-9'
+  );
+}
+
+function getAspectRatioPresetLabel(aspectRatio: BrowseAspectRatioPresetValue): string {
+  return BROWSE_ASPECT_RATIO_OPTIONS.find((option) => option.value === aspectRatio)?.label ?? aspectRatio;
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { AlertCircle, ArrowLeft, ImageOff, Upload } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useBrowseFilterPanel } from '@/components/browse-filter-panel-context';
 import { WallpaperGridSkeleton } from '@/components/grid';
 import { LoadMoreTrigger } from '@/components/LoadMoreTrigger';
@@ -11,10 +11,17 @@ import { Card, CardContent } from '@/components/ui/card';
 import { WallpaperGrid } from '@/components/WallpaperGrid';
 import { useWallpaperInfiniteQuery } from '@/hooks/useWallpaperInfiniteQuery';
 import {
+  BROWSE_ASPECT_RATIO_OPTIONS,
   BROWSE_FORMAT_OPTIONS,
+  getAspectRatioBadgeLabel,
+  getAspectRatioFilterValue,
+  getAspectRatioLabel,
   buildWallpaperFilter,
   getFormatBadgeLabel,
   parseBrowseSearch,
+  resolveClosestAspectRatioPreset,
+  type BrowseAspectRatioPresetValue,
+  type BrowseAspectRatioValue,
   type BrowseFormatValue,
 } from '@/lib/browse-filters';
 
@@ -24,14 +31,18 @@ export const Route = createFileRoute('/')({
 });
 
 export function HomePage() {
-  const { after, format } = Route.useSearch();
+  const { after, format, aspectRatio } = Route.useSearch();
   const navigate = useNavigate();
   const { isOpen } = useBrowseFilterPanel();
+  const deviceAspectRatioPreset = useDeviceAspectRatioPreset();
 
   const { data, isLoading, isFetchingNextPage, error, hasNextPage, fetchNextPage } =
     useWallpaperInfiniteQuery({
       initialCursor: after ?? null,
-      filter: buildWallpaperFilter(format),
+      filter: buildWallpaperFilter(
+        format,
+        getAspectRatioFilterValue(aspectRatio, deviceAspectRatioPreset),
+      ),
     });
 
   const handleLoadMore = useCallback(() => {
@@ -42,10 +53,32 @@ export function HomePage() {
     (nextFormat?: BrowseFormatValue) => {
       void navigate({
         to: '/',
-        search: (previous: { after?: string; format?: BrowseFormatValue }) => ({
+        search: (previous: {
+          after?: string;
+          format?: BrowseFormatValue;
+          aspectRatio?: BrowseAspectRatioValue;
+        }) => ({
           ...previous,
           after: undefined,
           format: nextFormat,
+        }),
+      });
+    },
+    [navigate]
+  );
+
+  const handleAspectRatioChange = useCallback(
+    (nextAspectRatio?: BrowseAspectRatioValue) => {
+      void navigate({
+        to: '/',
+        search: (previous: {
+          after?: string;
+          format?: BrowseFormatValue;
+          aspectRatio?: BrowseAspectRatioValue;
+        }) => ({
+          ...previous,
+          after: undefined,
+          aspectRatio: nextAspectRatio,
         }),
       });
     },
@@ -68,7 +101,10 @@ export function HomePage() {
         <BrowseFilterPanel
           isOpen={isOpen}
           selectedFormat={format}
+          selectedAspectRatio={aspectRatio}
+          deviceAspectRatioPreset={deviceAspectRatioPreset}
           onFormatChange={handleFormatChange}
+          onAspectRatioChange={handleAspectRatioChange}
         />
         <EmptyState hasCursor={!!after} />
       </div>
@@ -80,7 +116,10 @@ export function HomePage() {
       <BrowseFilterPanel
         isOpen={isOpen}
         selectedFormat={format}
+        selectedAspectRatio={aspectRatio}
+        deviceAspectRatioPreset={deviceAspectRatioPreset}
         onFormatChange={handleFormatChange}
+        onAspectRatioChange={handleAspectRatioChange}
       />
       <WallpaperGrid wallpapers={wallpapers} isLoadingMore={isFetchingNextPage} />
       <LoadMoreTrigger
@@ -95,54 +134,135 @@ export function HomePage() {
 function BrowseFilterPanel({
   isOpen,
   selectedFormat,
+  selectedAspectRatio,
+  deviceAspectRatioPreset,
   onFormatChange,
+  onAspectRatioChange,
 }: {
   isOpen: boolean;
   selectedFormat?: BrowseFormatValue;
+  selectedAspectRatio?: BrowseAspectRatioValue;
+  deviceAspectRatioPreset: BrowseAspectRatioPresetValue;
   onFormatChange: (format?: BrowseFormatValue) => void;
+  onAspectRatioChange: (aspectRatio?: BrowseAspectRatioValue) => void;
 }) {
   return (
     <section className="border-b bg-muted/20 px-4 py-3">
       <div className="mx-auto flex max-w-6xl flex-col gap-3">
         {isOpen ? (
-          <div className="flex flex-col gap-2">
-            <div>
-              <p className="text-sm font-medium text-foreground">Format</p>
-              <p className="text-muted-foreground text-xs">
-                Limit results to a specific wallpaper file type.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {BROWSE_FORMAT_OPTIONS.map((option) => {
-                const isSelected = option.value === (selectedFormat ?? 'any');
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <div>
+                <p className="text-sm font-medium text-foreground">Format</p>
+                <p className="text-muted-foreground text-xs">
+                  Limit results to a specific wallpaper file type.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {BROWSE_FORMAT_OPTIONS.map((option) => {
+                  const isSelected = option.value === (selectedFormat ?? 'any');
 
-                return (
-                  <Button
-                    key={option.value}
-                    type="button"
-                    variant={isSelected ? 'secondary' : 'outline'}
-                    size="sm"
-                    onClick={() =>
-                      onFormatChange(option.value === 'any' ? undefined : option.value)
-                    }
-                    aria-pressed={isSelected}
-                  >
-                    {option.label}
-                  </Button>
-                );
-              })}
+                  return (
+                    <Button
+                      key={option.value}
+                      type="button"
+                      variant={isSelected ? 'secondary' : 'outline'}
+                      size="sm"
+                      onClick={() =>
+                        onFormatChange(option.value === 'any' ? undefined : option.value)
+                      }
+                      aria-pressed={isSelected}
+                    >
+                      {option.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div>
+                <p className="text-sm font-medium text-foreground">Aspect ratio</p>
+                <p className="text-muted-foreground text-xs">
+                  Match results to common display and crop shapes.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {BROWSE_ASPECT_RATIO_OPTIONS.map((option) => {
+                  const isSelected = option.value === (selectedAspectRatio ?? 'any');
+
+                  return (
+                    <Button
+                      key={option.value}
+                      type="button"
+                      variant={isSelected ? 'secondary' : 'outline'}
+                      size="sm"
+                      onClick={() =>
+                        onAspectRatioChange(option.value === 'any' ? undefined : option.value)
+                      }
+                      aria-pressed={isSelected}
+                    >
+                      {option.value === 'device'
+                        ? getAspectRatioLabel(option.value, deviceAspectRatioPreset)
+                        : option.label}
+                    </Button>
+                  );
+                })}
+              </div>
             </div>
           </div>
         ) : null}
 
-        {!isOpen && selectedFormat ? (
+        {!isOpen && (selectedFormat || selectedAspectRatio) ? (
           <div className="flex flex-wrap gap-2">
-            <Badge variant="outline">{getFormatBadgeLabel(selectedFormat)}</Badge>
+            {selectedFormat ? <Badge variant="outline">{getFormatBadgeLabel(selectedFormat)}</Badge> : null}
+            {selectedAspectRatio ? (
+              <Badge variant="outline">
+                {getAspectRatioBadgeLabel(selectedAspectRatio, deviceAspectRatioPreset)}
+              </Badge>
+            ) : null}
           </div>
         ) : null}
       </div>
     </section>
   );
+}
+
+function useDeviceAspectRatioPreset(): BrowseAspectRatioPresetValue {
+  const [deviceAspectRatioPreset, setDeviceAspectRatioPreset] = useState<BrowseAspectRatioPresetValue>(
+    () => getDeviceAspectRatioPreset(),
+  );
+
+  useEffect(() => {
+    const syncDeviceAspectRatioPreset = () => {
+      setDeviceAspectRatioPreset(getDeviceAspectRatioPreset());
+    };
+
+    syncDeviceAspectRatioPreset();
+
+    const intervalId = window.setInterval(syncDeviceAspectRatioPreset, 1000);
+    window.addEventListener('resize', syncDeviceAspectRatioPreset);
+    window.addEventListener('orientationchange', syncDeviceAspectRatioPreset);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener('resize', syncDeviceAspectRatioPreset);
+      window.removeEventListener('orientationchange', syncDeviceAspectRatioPreset);
+    };
+  }, []);
+
+  return deviceAspectRatioPreset;
+}
+
+function getDeviceAspectRatioPreset(): BrowseAspectRatioPresetValue {
+  const width = window.screen?.width;
+  const height = window.screen?.height;
+
+  if (typeof width !== 'number' || typeof height !== 'number' || width <= 0 || height <= 0) {
+    return '16-9';
+  }
+
+  return resolveClosestAspectRatioPreset(width / height);
 }
 
 function LoadingState() {

--- a/apps/web/test/lib/browse-filters.test.ts
+++ b/apps/web/test/lib/browse-filters.test.ts
@@ -1,20 +1,26 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildAspectRatioFilter,
   buildWallpaperFilter,
+  getAspectRatioBadgeLabel,
+  getDeviceAspectRatioOptionLabel,
   getFormatBadgeLabel,
+  resolveClosestAspectRatioPreset,
   parseBrowseSearch,
 } from '@/lib/browse-filters';
 
 describe('browse filters', () => {
   it('keeps only supported format values from route search', () => {
-    expect(parseBrowseSearch({ after: 'cursor_123', format: 'png' })).toEqual({
+    expect(parseBrowseSearch({ after: 'cursor_123', format: 'png', aspectRatio: '16-9' })).toEqual({
       after: 'cursor_123',
       format: 'png',
+      aspectRatio: '16-9',
     });
 
-    expect(parseBrowseSearch({ after: 'cursor_123', format: 'gif' })).toEqual({
+    expect(parseBrowseSearch({ after: 'cursor_123', format: 'gif', aspectRatio: '3-1' })).toEqual({
       after: 'cursor_123',
       format: undefined,
+      aspectRatio: undefined,
     });
   });
 
@@ -25,9 +31,28 @@ describe('browse filters', () => {
     expect(buildWallpaperFilter('webp')).toEqual({ variants: { format: 'image/webp' } });
   });
 
+  it('maps preset and device aspect ratios to the wallpaper query filter', () => {
+    expect(buildAspectRatioFilter(undefined, '16-9')).toBeUndefined();
+    expect(buildAspectRatioFilter('21-9', '16-9')).toEqual({ variants: { aspectRatio: 21 / 9 } });
+    expect(buildAspectRatioFilter('device', '16-10')).toEqual({ variants: { aspectRatio: 16 / 10 } });
+  });
+
+  it('resolves the nearest supported aspect-ratio preset for a device ratio', () => {
+    expect(resolveClosestAspectRatioPreset(1920 / 1080)).toBe('16-9');
+    expect(resolveClosestAspectRatioPreset(1512 / 982)).toBe('16-10');
+    expect(resolveClosestAspectRatioPreset(1080 / 1920)).toBe('9-16');
+  });
+
   it('formats active filter badges using user-facing labels', () => {
     expect(getFormatBadgeLabel('jpeg')).toBe('Format: JPEG');
     expect(getFormatBadgeLabel('png')).toBe('Format: PNG');
     expect(getFormatBadgeLabel('webp')).toBe('Format: WebP');
+    expect(getAspectRatioBadgeLabel('16-10', '16-10')).toBe('Aspect ratio: 16:10');
+    expect(getAspectRatioBadgeLabel('device', '16-9')).toBe('Aspect ratio: Device 16:9');
+  });
+
+  it('formats the live device option label using the resolved preset', () => {
+    expect(getDeviceAspectRatioOptionLabel('16-9')).toBe('Device 16:9');
+    expect(getDeviceAspectRatioOptionLabel('21-9')).toBe('Device 21:9');
   });
 });

--- a/apps/web/test/routes/index.test.tsx
+++ b/apps/web/test/routes/index.test.tsx
@@ -5,6 +5,17 @@ import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 const mockUseSearch = vi.fn(() => ({}));
 const mockNavigate = vi.fn();
 
+function setScreenSize(width: number, height: number) {
+  Object.defineProperty(window, 'screen', {
+    configurable: true,
+    value: {
+      ...window.screen,
+      width,
+      height,
+    },
+  });
+}
+
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (config: Record<string, unknown>) => ({
     ...config,
@@ -45,7 +56,8 @@ import { HomePage } from '@/routes/index';
 describe('HomePage browse filters', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseSearch.mockReturnValue({ after: undefined, format: undefined });
+    setScreenSize(1920, 1080);
+    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: undefined });
     (useBrowseFilterPanel as Mock).mockReturnValue({
       isOpen: false,
       setIsOpen: vi.fn(),
@@ -88,7 +100,7 @@ describe('HomePage browse filters', () => {
   });
 
   it('passes the selected URL-backed format into wallpaper search', () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: 'png' });
+    mockUseSearch.mockReturnValue({ after: undefined, format: 'png', aspectRatio: undefined });
 
     render(<HomePage />);
 
@@ -98,8 +110,30 @@ describe('HomePage browse filters', () => {
     });
   });
 
+  it('passes the selected URL-backed aspect ratio into wallpaper search', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: '21-9' });
+
+    render(<HomePage />);
+
+    expect(useWallpaperInfiniteQuery).toHaveBeenCalledWith({
+      filter: { variants: { aspectRatio: 21 / 9 } },
+      initialCursor: null,
+    });
+  });
+
+  it('resolves the device aspect ratio before querying wallpapers', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: 'device' });
+
+    render(<HomePage />);
+
+    expect(useWallpaperInfiniteQuery).toHaveBeenCalledWith({
+      filter: { variants: { aspectRatio: 16 / 9 } },
+      initialCursor: null,
+    });
+  });
+
   it('shows the active format as a neutral badge when the panel is collapsed', () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: 'png' });
+    mockUseSearch.mockReturnValue({ after: undefined, format: 'png', aspectRatio: undefined });
 
     render(<HomePage />);
 
@@ -107,10 +141,18 @@ describe('HomePage browse filters', () => {
     expect(screen.queryByText('JPEG')).not.toBeInTheDocument();
   });
 
+  it('shows the resolved device aspect ratio as a neutral badge when the panel is collapsed', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: 'device' });
+
+    render(<HomePage />);
+
+    expect(screen.getByText('Aspect ratio: Device 16:9')).toBeInTheDocument();
+  });
+
   it('updates the route search state when a format is selected', async () => {
     const user = userEvent.setup();
 
-    mockUseSearch.mockReturnValue({ after: 'cursor_123', format: undefined });
+    mockUseSearch.mockReturnValue({ after: 'cursor_123', format: undefined, aspectRatio: undefined });
     (useBrowseFilterPanel as Mock).mockReturnValue({
       isOpen: true,
       setIsOpen: vi.fn(),
@@ -127,9 +169,50 @@ describe('HomePage browse filters', () => {
     });
 
     const navigateCall = mockNavigate.mock.calls[0][0];
-    expect(navigateCall.search({ after: 'cursor_123', format: undefined })).toEqual({
+    expect(navigateCall.search({ after: 'cursor_123', format: undefined, aspectRatio: undefined })).toEqual({
       after: undefined,
       format: 'png',
+      aspectRatio: undefined,
     });
+  });
+
+  it('updates the route search state when an aspect ratio is selected', async () => {
+    const user = userEvent.setup();
+
+    mockUseSearch.mockReturnValue({ after: 'cursor_123', format: 'png', aspectRatio: undefined });
+    (useBrowseFilterPanel as Mock).mockReturnValue({
+      isOpen: true,
+      setIsOpen: vi.fn(),
+      toggle: vi.fn(),
+    });
+
+    render(<HomePage />);
+
+    await user.click(screen.getByRole('button', { name: '16:10' }));
+
+    const navigateCall = mockNavigate.mock.calls[0][0];
+    expect(navigateCall.search({ after: 'cursor_123', format: 'png', aspectRatio: undefined })).toEqual({
+      after: undefined,
+      format: 'png',
+      aspectRatio: '16-10',
+    });
+  });
+
+  it('updates the device label when the active display context changes', async () => {
+    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: 'device' });
+    (useBrowseFilterPanel as Mock).mockReturnValue({
+      isOpen: true,
+      setIsOpen: vi.fn(),
+      toggle: vi.fn(),
+    });
+
+    render(<HomePage />);
+
+    expect(screen.getByRole('button', { name: 'Device 16:9' })).toBeInTheDocument();
+
+    setScreenSize(1080, 1920);
+    window.dispatchEvent(new Event('resize'));
+
+    expect(await screen.findByRole('button', { name: 'Device 9:16' })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add aspect ratio browse filter options, parsing, labels, and query filter construction
- support a `device` aspect ratio option that resolves to the closest preset from the current screen dimensions
- update the home browse UI to select, persist, and display active aspect ratio filters alongside format filters
- extend route and filter tests to cover aspect ratio selection, device resolution, and badge rendering

## Testing
- Not run
- Added unit test coverage for browse filter parsing, aspect ratio filter mapping, nearest preset resolution, and badge labels in `apps/web/test/lib/browse-filters.test.ts`
- Added route/UI test coverage for passing aspect ratio filters into wallpaper queries, updating URL search state, and refreshing the device label on screen changes in `apps/web/test/routes/index.test.tsx`