### PR TITLE
Add color sorting to browse filters

### DIFF
--- a/apps/web/src/hooks/useWallpaperInfiniteQuery.ts
+++ b/apps/web/src/hooks/useWallpaperInfiniteQuery.ts
@@ -1,11 +1,12 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { graphqlClient } from '@/lib/graphql/client';
 import { SEARCH_WALLPAPERS } from '@/lib/graphql/queries';
-import type { WallpaperConnection, WallpaperFilter } from '@/lib/graphql/types';
+import type { WallpaperConnection, WallpaperFilter, WallpaperSort } from '@/lib/graphql/types';
 
 interface UseWallpaperInfiniteQueryOptions {
   initialCursor?: string | null;
   filter?: WallpaperFilter;
+  sort?: WallpaperSort;
   pageSize?: number;
 }
 
@@ -16,13 +17,15 @@ interface SearchWallpapersResponse {
 export function useWallpaperInfiniteQuery({
   initialCursor = null,
   filter,
+  sort,
   pageSize = 20,
 }: UseWallpaperInfiniteQueryOptions = {}) {
   return useInfiniteQuery({
-    queryKey: ['wallpapers', 'infinite', { filter, initialCursor }],
+    queryKey: ['wallpapers', 'infinite', { filter, initialCursor, sort }],
     queryFn: async ({ pageParam }) => {
       const response = await graphqlClient.request<SearchWallpapersResponse>(SEARCH_WALLPAPERS, {
         filter,
+        sort,
         first: pageSize,
         after: pageParam,
       });

--- a/apps/web/src/lib/browse-filters.ts
+++ b/apps/web/src/lib/browse-filters.ts
@@ -1,4 +1,4 @@
-import type { WallpaperFilter } from '@/lib/graphql/types';
+import type { WallpaperFilter, WallpaperSort } from '@/lib/graphql/types';
 
 export const BROWSE_FORMAT_OPTIONS = [
   { value: 'any', label: 'Any' },
@@ -29,11 +29,13 @@ export interface BrowseSearchState {
   after?: string;
   format?: BrowseFormatValue;
   aspectRatio?: BrowseAspectRatioValue;
+  color?: string;
 }
 
 export function parseBrowseSearch(search: Record<string, unknown>): BrowseSearchState {
   return {
     after: typeof search.after === 'string' ? search.after : undefined,
+    color: normalizeBrowseColorValue(search.color),
     format: isBrowseFormatValue(search.format) ? search.format : undefined,
     aspectRatio: isBrowseAspectRatioValue(search.aspectRatio) ? search.aspectRatio : undefined,
   };
@@ -78,6 +80,24 @@ export function buildAspectRatioFilter(
       aspectRatio: resolvedAspectRatio,
     },
   };
+}
+
+export function buildWallpaperSort(color?: string): WallpaperSort | undefined {
+  const normalizedColor = normalizeBrowseColorValue(color);
+
+  if (!normalizedColor) {
+    return undefined;
+  }
+
+  return {
+    color: {
+      colors: [{ amount: 1, color: normalizedColor }],
+    },
+  };
+}
+
+export function getColorBadgeLabel(color: string): string {
+  return `Color: ${normalizeBrowseColorValue(color) ?? color.toUpperCase()}`;
 }
 
 export function getFormatBadgeLabel(format: BrowseFormatValue): string {
@@ -161,4 +181,12 @@ function isBrowseAspectRatioValue(value: unknown): value is BrowseAspectRatioVal
 
 function getAspectRatioPresetLabel(aspectRatio: BrowseAspectRatioPresetValue): string {
   return BROWSE_ASPECT_RATIO_OPTIONS.find((option) => option.value === aspectRatio)?.label ?? aspectRatio;
+}
+
+function normalizeBrowseColorValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  return /^#[0-9a-fA-F]{6}$/.test(value) ? value.toUpperCase() : undefined;
 }

--- a/apps/web/src/lib/graphql/queries.ts
+++ b/apps/web/src/lib/graphql/queries.ts
@@ -3,10 +3,11 @@ import { gql } from 'graphql-request';
 export const SEARCH_WALLPAPERS = gql`
   query SearchWallpapers(
     $filter: WallpaperFilter
+    $sort: WallpaperSort
     $first: Int
     $after: String
   ) {
-    searchWallpapers(filter: $filter, first: $first, after: $after) {
+    searchWallpapers(filter: $filter, sort: $sort, first: $first, after: $after) {
       edges {
         node {
           wallpaperId

--- a/apps/web/src/lib/graphql/types.ts
+++ b/apps/web/src/lib/graphql/types.ts
@@ -39,6 +39,20 @@ export interface WallpaperFilter {
   variants?: VariantFilter;
 }
 
+export interface WallpaperSort {
+  color?: ColorSort;
+}
+
+export interface ColorSort {
+  colors: ColorInput[];
+}
+
+export interface ColorInput {
+  color: string;
+  amount: number;
+  spread?: number;
+}
+
 export interface VariantFilter {
   width?: number;
   height?: number;

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { AlertCircle, ArrowLeft, ImageOff, Upload } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useBrowseFilterPanel } from '@/components/browse-filter-panel-context';
 import { WallpaperGridSkeleton } from '@/components/grid';
 import { LoadMoreTrigger } from '@/components/LoadMoreTrigger';
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { WallpaperGrid } from '@/components/WallpaperGrid';
 import { useWallpaperInfiniteQuery } from '@/hooks/useWallpaperInfiniteQuery';
 import {
@@ -17,6 +18,8 @@ import {
   getAspectRatioFilterValue,
   getAspectRatioLabel,
   buildWallpaperFilter,
+  buildWallpaperSort,
+  getColorBadgeLabel,
   getFormatBadgeLabel,
   parseBrowseSearch,
   resolveClosestAspectRatioPreset,
@@ -25,16 +28,21 @@ import {
   type BrowseFormatValue,
 } from '@/lib/browse-filters';
 
+const COLOR_INPUT_DEBOUNCE_MS = 300;
+const DEFAULT_BROWSE_COLOR = '#000000';
+
 export const Route = createFileRoute('/')({
   component: HomePage,
   validateSearch: parseBrowseSearch,
 });
 
 export function HomePage() {
-  const { after, format, aspectRatio } = Route.useSearch();
+  const { after, color, format, aspectRatio } = Route.useSearch();
   const navigate = useNavigate();
   const { isOpen } = useBrowseFilterPanel();
   const deviceAspectRatioPreset = useDeviceAspectRatioPreset();
+  const [draftColor, setDraftColor] = useState(color ?? DEFAULT_BROWSE_COLOR);
+  const colorChangeTimeoutRef = useRef<number | undefined>(undefined);
 
   const { data, isLoading, isFetchingNextPage, error, hasNextPage, fetchNextPage } =
     useWallpaperInfiniteQuery({
@@ -43,6 +51,7 @@ export function HomePage() {
         format,
         getAspectRatioFilterValue(aspectRatio, deviceAspectRatioPreset),
       ),
+      sort: buildWallpaperSort(color),
     });
 
   const handleLoadMore = useCallback(() => {
@@ -85,6 +94,63 @@ export function HomePage() {
     [navigate]
   );
 
+  const handleColorChange = useCallback(
+    (nextColor?: string) => {
+      void navigate({
+        to: '/',
+        search: (previous: {
+          after?: string;
+          color?: string;
+          format?: BrowseFormatValue;
+          aspectRatio?: BrowseAspectRatioValue;
+        }) => ({
+          ...previous,
+          after: undefined,
+          color: nextColor,
+        }),
+      });
+    },
+    [navigate]
+  );
+
+  const handleColorInputChange = useCallback(
+    (nextColor: string) => {
+      const normalizedColor = nextColor.toUpperCase();
+
+      setDraftColor(normalizedColor);
+
+      if (colorChangeTimeoutRef.current) {
+        window.clearTimeout(colorChangeTimeoutRef.current);
+      }
+
+      colorChangeTimeoutRef.current = window.setTimeout(() => {
+        handleColorChange(normalizedColor);
+      }, COLOR_INPUT_DEBOUNCE_MS);
+    },
+    [handleColorChange]
+  );
+
+  const handleClearColor = useCallback(() => {
+    if (colorChangeTimeoutRef.current) {
+      window.clearTimeout(colorChangeTimeoutRef.current);
+      colorChangeTimeoutRef.current = undefined;
+    }
+
+    setDraftColor(DEFAULT_BROWSE_COLOR);
+    handleColorChange(undefined);
+  }, [handleColorChange]);
+
+  useEffect(() => {
+    setDraftColor(color ?? DEFAULT_BROWSE_COLOR);
+  }, [color]);
+
+  useEffect(() => {
+    return () => {
+      if (colorChangeTimeoutRef.current) {
+        window.clearTimeout(colorChangeTimeoutRef.current);
+      }
+    };
+  }, []);
   if (isLoading) {
     return <LoadingState />;
   }
@@ -100,9 +166,13 @@ export function HomePage() {
       <div>
         <BrowseFilterPanel
           isOpen={isOpen}
+          draftColor={draftColor}
+          selectedColor={color}
           selectedFormat={format}
           selectedAspectRatio={aspectRatio}
           deviceAspectRatioPreset={deviceAspectRatioPreset}
+          onClearColor={handleClearColor}
+          onColorInputChange={handleColorInputChange}
           onFormatChange={handleFormatChange}
           onAspectRatioChange={handleAspectRatioChange}
         />
@@ -115,9 +185,13 @@ export function HomePage() {
     <div>
       <BrowseFilterPanel
         isOpen={isOpen}
+        draftColor={draftColor}
+        selectedColor={color}
         selectedFormat={format}
         selectedAspectRatio={aspectRatio}
         deviceAspectRatioPreset={deviceAspectRatioPreset}
+        onClearColor={handleClearColor}
+        onColorInputChange={handleColorInputChange}
         onFormatChange={handleFormatChange}
         onAspectRatioChange={handleAspectRatioChange}
       />
@@ -132,17 +206,25 @@ export function HomePage() {
 }
 
 function BrowseFilterPanel({
+  draftColor,
   isOpen,
+  selectedColor,
   selectedFormat,
   selectedAspectRatio,
   deviceAspectRatioPreset,
+  onClearColor,
+  onColorInputChange,
   onFormatChange,
   onAspectRatioChange,
 }: {
+  draftColor: string;
   isOpen: boolean;
+  selectedColor?: string;
   selectedFormat?: BrowseFormatValue;
   selectedAspectRatio?: BrowseAspectRatioValue;
   deviceAspectRatioPreset: BrowseAspectRatioPresetValue;
+  onClearColor: () => void;
+  onColorInputChange: (color: string) => void;
   onFormatChange: (format?: BrowseFormatValue) => void;
   onAspectRatioChange: (aspectRatio?: BrowseAspectRatioValue) => void;
 }) {
@@ -151,6 +233,39 @@ function BrowseFilterPanel({
       <div className="mx-auto flex max-w-6xl flex-col gap-3">
         {isOpen ? (
           <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <div>
+                <label htmlFor="browse-color" className="text-sm font-medium text-foreground">
+                  Color
+                </label>
+                <p id="browse-color-description" className="text-muted-foreground text-xs">
+                  Bias results toward a specific visual tone.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Input
+                  id="browse-color"
+                  type="color"
+                  value={draftColor}
+                  aria-describedby="browse-color-description"
+                  className="h-10 w-14 cursor-pointer p-1"
+                  onInput={(event) => onColorInputChange(event.currentTarget.value)}
+                />
+                <span className="text-muted-foreground text-xs font-medium uppercase">
+                  {draftColor}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={onClearColor}
+                  disabled={!selectedColor}
+                >
+                  Clear color
+                </Button>
+              </div>
+            </div>
+
             <div className="flex flex-col gap-2">
               <div>
                 <p className="text-sm font-medium text-foreground">Format</p>
@@ -213,9 +328,22 @@ function BrowseFilterPanel({
           </div>
         ) : null}
 
-        {!isOpen && (selectedFormat || selectedAspectRatio) ? (
+        {!isOpen && (selectedColor || selectedFormat || selectedAspectRatio) ? (
           <div className="flex flex-wrap gap-2">
-            {selectedFormat ? <Badge variant="outline">{getFormatBadgeLabel(selectedFormat)}</Badge> : null}
+            {selectedColor ? (
+              <Badge variant="outline">
+                <span
+                  data-testid="active-color-dot"
+                  aria-hidden="true"
+                  className="size-2 rounded-full border border-black/10"
+                  style={{ backgroundColor: selectedColor }}
+                />
+                {getColorBadgeLabel(selectedColor)}
+              </Badge>
+            ) : null}
+            {selectedFormat ? (
+              <Badge variant="outline">{getFormatBadgeLabel(selectedFormat)}</Badge>
+            ) : null}
             {selectedAspectRatio ? (
               <Badge variant="outline">
                 {getAspectRatioBadgeLabel(selectedAspectRatio, deviceAspectRatioPreset)}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/lib/browse-filters';
 
 const COLOR_INPUT_DEBOUNCE_MS = 300;
-const DEFAULT_BROWSE_COLOR = '#000000';
+const FALLBACK_COLOR_INPUT_VALUE = '#FFFFFF';
 
 export const Route = createFileRoute('/')({
   component: HomePage,
@@ -41,7 +41,7 @@ export function HomePage() {
   const navigate = useNavigate();
   const { isOpen } = useBrowseFilterPanel();
   const deviceAspectRatioPreset = useDeviceAspectRatioPreset();
-  const [draftColor, setDraftColor] = useState(color ?? DEFAULT_BROWSE_COLOR);
+  const [draftColor, setDraftColor] = useState(color ?? FALLBACK_COLOR_INPUT_VALUE);
   const colorChangeTimeoutRef = useRef<number | undefined>(undefined);
 
   const { data, isLoading, isFetchingNextPage, error, hasNextPage, fetchNextPage } =
@@ -136,12 +136,12 @@ export function HomePage() {
       colorChangeTimeoutRef.current = undefined;
     }
 
-    setDraftColor(DEFAULT_BROWSE_COLOR);
+    setDraftColor(FALLBACK_COLOR_INPUT_VALUE);
     handleColorChange(undefined);
   }, [handleColorChange]);
 
   useEffect(() => {
-    setDraftColor(color ?? DEFAULT_BROWSE_COLOR);
+    setDraftColor(color ?? FALLBACK_COLOR_INPUT_VALUE);
   }, [color]);
 
   useEffect(() => {
@@ -252,7 +252,7 @@ function BrowseFilterPanel({
                   onInput={(event) => onColorInputChange(event.currentTarget.value)}
                 />
                 <span className="text-muted-foreground text-xs font-medium uppercase">
-                  {draftColor}
+                  {selectedColor ?? 'No color selected'}
                 </span>
                 <Button
                   type="button"

--- a/apps/web/test/lib/browse-filters.test.ts
+++ b/apps/web/test/lib/browse-filters.test.ts
@@ -4,21 +4,25 @@ import {
   buildWallpaperFilter,
   getAspectRatioBadgeLabel,
   getDeviceAspectRatioOptionLabel,
+  buildWallpaperSort,
+  getColorBadgeLabel,
   getFormatBadgeLabel,
-  resolveClosestAspectRatioPreset,
   parseBrowseSearch,
+  resolveClosestAspectRatioPreset,
 } from '@/lib/browse-filters';
 
 describe('browse filters', () => {
   it('keeps only supported format values from route search', () => {
-    expect(parseBrowseSearch({ after: 'cursor_123', format: 'png', aspectRatio: '16-9' })).toEqual({
+    expect(parseBrowseSearch({ after: 'cursor_123', color: '#ff0000', format: 'png', aspectRatio: '16-9' })).toEqual({
       after: 'cursor_123',
+      color: '#FF0000',
       format: 'png',
       aspectRatio: '16-9',
     });
 
-    expect(parseBrowseSearch({ after: 'cursor_123', format: 'gif', aspectRatio: '3-1' })).toEqual({
+    expect(parseBrowseSearch({ after: 'cursor_123', color: 'red', format: 'gif', aspectRatio: '3-1' })).toEqual({
       after: 'cursor_123',
+      color: undefined,
       format: undefined,
       aspectRatio: undefined,
     });
@@ -43,7 +47,18 @@ describe('browse filters', () => {
     expect(resolveClosestAspectRatioPreset(1080 / 1920)).toBe('9-16');
   });
 
+  it('maps a selected color to the wallpaper query sort', () => {
+    expect(buildWallpaperSort(undefined)).toBeUndefined();
+    expect(buildWallpaperSort('invalid')).toBeUndefined();
+    expect(buildWallpaperSort('#ff0000')).toEqual({
+      color: {
+        colors: [{ amount: 1, color: '#FF0000' }],
+      },
+    });
+  });
+
   it('formats active filter badges using user-facing labels', () => {
+    expect(getColorBadgeLabel('#ff0000')).toBe('Color: #FF0000');
     expect(getFormatBadgeLabel('jpeg')).toBe('Format: JPEG');
     expect(getFormatBadgeLabel('png')).toBe('Format: PNG');
     expect(getFormatBadgeLabel('webp')).toBe('Format: WebP');

--- a/apps/web/test/routes/index.test.tsx
+++ b/apps/web/test/routes/index.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 const mockUseSearch = vi.fn(() => ({}));
@@ -57,7 +56,7 @@ describe('HomePage browse filters', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setScreenSize(1920, 1080);
-    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: undefined });
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: undefined, aspectRatio: undefined });
     (useBrowseFilterPanel as Mock).mockReturnValue({
       isOpen: false,
       setIsOpen: vi.fn(),
@@ -100,40 +99,59 @@ describe('HomePage browse filters', () => {
   });
 
   it('passes the selected URL-backed format into wallpaper search', () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: 'png', aspectRatio: undefined });
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: 'png', aspectRatio: undefined });
 
     render(<HomePage />);
 
     expect(useWallpaperInfiniteQuery).toHaveBeenCalledWith({
       filter: { variants: { format: 'image/png' } },
       initialCursor: null,
+      sort: undefined,
     });
   });
 
   it('passes the selected URL-backed aspect ratio into wallpaper search', () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: '21-9' });
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: undefined, aspectRatio: '21-9' });
 
     render(<HomePage />);
 
     expect(useWallpaperInfiniteQuery).toHaveBeenCalledWith({
       filter: { variants: { aspectRatio: 21 / 9 } },
       initialCursor: null,
+      sort: undefined,
+    });
+  });
+
+  it('passes the selected URL-backed color into wallpaper search sort', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, color: '#ff0000', format: undefined, aspectRatio: undefined });
+
+    render(<HomePage />);
+
+    expect(useWallpaperInfiniteQuery).toHaveBeenCalledWith({
+      filter: undefined,
+      initialCursor: null,
+      sort: {
+        color: {
+          colors: [{ amount: 1, color: '#FF0000' }],
+        },
+      },
     });
   });
 
   it('resolves the device aspect ratio before querying wallpapers', () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: 'device' });
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: undefined, aspectRatio: 'device' });
 
     render(<HomePage />);
 
     expect(useWallpaperInfiniteQuery).toHaveBeenCalledWith({
       filter: { variants: { aspectRatio: 16 / 9 } },
       initialCursor: null,
+      sort: undefined,
     });
   });
 
   it('shows the active format as a neutral badge when the panel is collapsed', () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: 'png', aspectRatio: undefined });
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: 'png', aspectRatio: undefined });
 
     render(<HomePage />);
 
@@ -142,17 +160,24 @@ describe('HomePage browse filters', () => {
   });
 
   it('shows the resolved device aspect ratio as a neutral badge when the panel is collapsed', () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: 'device' });
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: undefined, aspectRatio: 'device' });
 
     render(<HomePage />);
 
     expect(screen.getByText('Aspect ratio: Device 16:9')).toBeInTheDocument();
   });
 
-  it('updates the route search state when a format is selected', async () => {
-    const user = userEvent.setup();
+  it('shows the active color as a neutral badge with a colored dot when the panel is collapsed', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, color: '#ff0000', format: undefined, aspectRatio: undefined });
 
-    mockUseSearch.mockReturnValue({ after: 'cursor_123', format: undefined, aspectRatio: undefined });
+    render(<HomePage />);
+
+    expect(screen.getByText('Color: #FF0000')).toBeInTheDocument();
+    expect(screen.getByTestId('active-color-dot')).toHaveStyle({ backgroundColor: '#FF0000' });
+  });
+
+  it('updates the route search state when a format is selected', () => {
+    mockUseSearch.mockReturnValue({ after: 'cursor_123', color: undefined, format: undefined, aspectRatio: undefined });
     (useBrowseFilterPanel as Mock).mockReturnValue({
       isOpen: true,
       setIsOpen: vi.fn(),
@@ -161,7 +186,7 @@ describe('HomePage browse filters', () => {
 
     render(<HomePage />);
 
-    await user.click(screen.getByRole('button', { name: 'PNG' }));
+    fireEvent.click(screen.getByRole('button', { name: 'PNG' }));
 
     expect(mockNavigate).toHaveBeenCalledWith({
       search: expect.any(Function),
@@ -169,17 +194,18 @@ describe('HomePage browse filters', () => {
     });
 
     const navigateCall = mockNavigate.mock.calls[0][0];
-    expect(navigateCall.search({ after: 'cursor_123', format: undefined, aspectRatio: undefined })).toEqual({
+    expect(navigateCall.search({ after: 'cursor_123', color: undefined, format: undefined, aspectRatio: undefined })).toEqual({
       after: undefined,
+      color: undefined,
       format: 'png',
       aspectRatio: undefined,
     });
   });
 
-  it('updates the route search state when an aspect ratio is selected', async () => {
-    const user = userEvent.setup();
+  it('debounces route search updates when the color changes', () => {
+    vi.useFakeTimers();
 
-    mockUseSearch.mockReturnValue({ after: 'cursor_123', format: 'png', aspectRatio: undefined });
+    mockUseSearch.mockReturnValue({ after: 'cursor_123', color: undefined, format: 'png', aspectRatio: undefined });
     (useBrowseFilterPanel as Mock).mockReturnValue({
       isOpen: true,
       setIsOpen: vi.fn(),
@@ -188,18 +214,57 @@ describe('HomePage browse filters', () => {
 
     render(<HomePage />);
 
-    await user.click(screen.getByRole('button', { name: '16:10' }));
+    fireEvent.input(screen.getByLabelText('Color'), {
+      target: { value: '#00ff00' },
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(299);
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(mockNavigate).toHaveBeenCalledWith({
+      search: expect.any(Function),
+      to: '/',
+    });
 
     const navigateCall = mockNavigate.mock.calls[0][0];
-    expect(navigateCall.search({ after: 'cursor_123', format: 'png', aspectRatio: undefined })).toEqual({
+    expect(
+      navigateCall.search({ after: 'cursor_123', color: undefined, format: 'png', aspectRatio: undefined })
+    ).toEqual({
       after: undefined,
+      color: '#00FF00',
+      format: 'png',
+      aspectRatio: undefined,
+    });
+
+    vi.useRealTimers();
+  });
+
+  it('updates the route search state when an aspect ratio is selected', () => {
+    mockUseSearch.mockReturnValue({ after: 'cursor_123', color: undefined, format: 'png', aspectRatio: undefined });
+    (useBrowseFilterPanel as Mock).mockReturnValue({
+      isOpen: true,
+      setIsOpen: vi.fn(),
+      toggle: vi.fn(),
+    });
+
+    render(<HomePage />);
+
+    fireEvent.click(screen.getByRole('button', { name: '16:10' }));
+
+    const navigateCall = mockNavigate.mock.calls[0][0];
+    expect(navigateCall.search({ after: 'cursor_123', color: undefined, format: 'png', aspectRatio: undefined })).toEqual({
+      after: undefined,
+      color: undefined,
       format: 'png',
       aspectRatio: '16-10',
     });
   });
 
   it('updates the device label when the active display context changes', async () => {
-    mockUseSearch.mockReturnValue({ after: undefined, format: undefined, aspectRatio: 'device' });
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: undefined, aspectRatio: 'device' });
     (useBrowseFilterPanel as Mock).mockReturnValue({
       isOpen: true,
       setIsOpen: vi.fn(),
@@ -214,5 +279,31 @@ describe('HomePage browse filters', () => {
     window.dispatchEvent(new Event('resize'));
 
     expect(await screen.findByRole('button', { name: 'Device 9:16' })).toBeInTheDocument();
+  });
+
+  it('clears the color filter immediately', () => {
+    mockUseSearch.mockReturnValue({ after: 'cursor_123', color: '#FF0000', format: 'png', aspectRatio: undefined });
+    (useBrowseFilterPanel as Mock).mockReturnValue({
+      isOpen: true,
+      setIsOpen: vi.fn(),
+      toggle: vi.fn(),
+    });
+
+    render(<HomePage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear color' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      search: expect.any(Function),
+      to: '/',
+    });
+
+    const navigateCall = mockNavigate.mock.calls[0][0];
+    expect(navigateCall.search({ after: 'cursor_123', color: '#FF0000', format: 'png', aspectRatio: undefined })).toEqual({
+      after: undefined,
+      color: undefined,
+      format: 'png',
+      aspectRatio: undefined,
+    });
   });
 });

--- a/apps/web/test/routes/index.test.tsx
+++ b/apps/web/test/routes/index.test.tsx
@@ -176,6 +176,20 @@ describe('HomePage browse filters', () => {
     expect(screen.getByTestId('active-color-dot')).toHaveStyle({ backgroundColor: '#FF0000' });
   });
 
+  it('does not show black as a fake selected color when the color filter is unset', () => {
+    mockUseSearch.mockReturnValue({ after: undefined, color: undefined, format: undefined, aspectRatio: undefined });
+    (useBrowseFilterPanel as Mock).mockReturnValue({
+      isOpen: true,
+      setIsOpen: vi.fn(),
+      toggle: vi.fn(),
+    });
+
+    render(<HomePage />);
+
+    expect(screen.getByText('No color selected')).toBeInTheDocument();
+    expect(screen.queryByText('#000000')).not.toBeInTheDocument();
+  });
+
   it('updates the route search state when a format is selected', () => {
     mockUseSearch.mockReturnValue({ after: 'cursor_123', color: undefined, format: undefined, aspectRatio: undefined });
     (useBrowseFilterPanel as Mock).mockReturnValue({


### PR DESCRIPTION
## Summary
- add color-based sorting to the browse wallpaper query and GraphQL types
- support `color` in browse search parsing, query construction, and active filter badges
- add a debounced color picker UI with clear behavior in the home browse filters
- avoid showing a misleading default color when no color filter is selected
- expand route and browse filter tests to cover color sorting and UI behavior

## Testing
- Not run
- verified coverage was added for browse search parsing, color sort mapping, badge labels, debounced color updates, and clearing the color filter