### PR TITLE
Derive media URLs from request origin

### DIFF
--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -26,7 +26,14 @@ REDIS_ENABLED=true
 # OpenTelemetry
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_SERVICE_NAME=gateway
+
+# Media URLs
+# MEDIA_SERVICE_URL is the internal/fallback service URL. GraphQL variant URLs
+# are generated from the incoming browser/proxy origin by default, using
+# MEDIA_PUBLIC_PATH. Set MEDIA_PUBLIC_BASE_URL to force a fixed public URL.
 MEDIA_SERVICE_URL=http://localhost:3003
+MEDIA_PUBLIC_PATH=/media
+MEDIA_PUBLIC_BASE_URL=
 
 # GraphQL Security
 GRAPHQL_MAX_DEPTH=10

--- a/apps/gateway/src/config.ts
+++ b/apps/gateway/src/config.ts
@@ -31,6 +31,8 @@ const configSchema = z.object({
   // OTEL config
   ...OtelConfigSchema.shape,
   mediaServiceUrl: z.string().url(),
+  mediaPublicBaseUrl: z.string().url().optional(),
+  mediaPublicPath: z.string().min(1).default('/media'),
 
   // GraphQL Security
   graphqlMaxDepth: z.number().int().positive().default(5),
@@ -85,6 +87,8 @@ export function loadConfig(): Config {
     otelServiceName: getEnv('OTEL_SERVICE_NAME', 'gateway'),
 
     mediaServiceUrl: getEnv('MEDIA_SERVICE_URL'),
+    mediaPublicBaseUrl: process.env.MEDIA_PUBLIC_BASE_URL || undefined,
+    mediaPublicPath: getEnv('MEDIA_PUBLIC_PATH', '/media'),
 
     // GraphQL Security
     graphqlMaxDepth: parseIntEnv(process.env.GRAPHQL_MAX_DEPTH, 5),

--- a/apps/gateway/src/graphql/resolvers.ts
+++ b/apps/gateway/src/graphql/resolvers.ts
@@ -1,3 +1,4 @@
+import type { IncomingHttpHeaders } from 'node:http';
 import { Attributes, recordCounter, recordHistogram, withSpan } from '@wallpaperdb/core/telemetry';
 import { inject, singleton } from 'tsyringe';
 import type { Config } from '../config.js';
@@ -49,6 +50,16 @@ interface GetWallpaperArgs {
   wallpaperId: string;
 }
 
+interface GraphQLContext {
+  reply?: {
+    request?: {
+      headers: IncomingHttpHeaders;
+      hostname?: string;
+      protocol?: string;
+    };
+  };
+}
+
 interface Variant {
   width: number;
   height: number;
@@ -93,8 +104,12 @@ export class Resolvers {
         },
       },
       Variant: {
-        url: (parent: Variant & { __wallpaperId?: string }) => {
-          return this.getVariantUrl(parent);
+        url: (
+          parent: Variant & { __wallpaperId?: string },
+          _args: unknown,
+          context: GraphQLContext
+        ) => {
+          return this.getVariantUrl(parent, context);
         },
       },
     };
@@ -264,10 +279,76 @@ export class Resolvers {
   /**
    * Get URL for a variant (field resolver)
    */
-  private getVariantUrl(variant: Variant & { __wallpaperId?: string }): string {
-    const mediaServiceUrl = this.config.mediaServiceUrl;
+  private getVariantUrl(
+    variant: Variant & { __wallpaperId?: string },
+    context?: GraphQLContext
+  ): string {
+    const mediaServiceUrl = this.getPublicMediaBaseUrl(context);
     const wallpaperId = variant.__wallpaperId;
 
     return `${mediaServiceUrl}/wallpapers/${wallpaperId}?w=${variant.width}&h=${variant.height}&format=${variant.format}`;
   }
+
+  private getPublicMediaBaseUrl(context?: GraphQLContext): string {
+    if (this.config.mediaPublicBaseUrl) {
+      return trimTrailingSlash(this.config.mediaPublicBaseUrl);
+    }
+
+    const requestOrigin = getRequestOrigin(context);
+    if (!requestOrigin) {
+      return trimTrailingSlash(this.config.mediaServiceUrl);
+    }
+
+    const mediaPath = this.config.mediaPublicPath.startsWith('/')
+      ? this.config.mediaPublicPath
+      : `/${this.config.mediaPublicPath}`;
+
+    return `${requestOrigin}${trimTrailingSlash(mediaPath)}`;
+  }
+}
+
+function getRequestOrigin(context?: GraphQLContext): string | undefined {
+  const request = context?.reply?.request;
+  if (!request) {
+    return undefined;
+  }
+
+  const origin = firstHeaderValue(request.headers.origin);
+  if (origin && isHttpOrigin(origin)) {
+    return trimTrailingSlash(origin);
+  }
+
+  const forwardedProto = firstHeaderValue(request.headers['x-forwarded-proto']);
+  const forwardedHost = firstHeaderValue(request.headers['x-forwarded-host']);
+
+  if (!forwardedProto || !forwardedHost) {
+    return undefined;
+  }
+
+  const normalizedProtocol = forwardedProto.split(',')[0]?.trim();
+  const normalizedHost = forwardedHost.split(',')[0]?.trim();
+
+  if (!normalizedHost || !normalizedProtocol) {
+    return undefined;
+  }
+
+  const forwardedOrigin = `${normalizedProtocol}://${normalizedHost}`;
+  return isHttpOrigin(forwardedOrigin) ? forwardedOrigin : undefined;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function isHttpOrigin(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.pathname === '/';
+  } catch {
+    return false;
+  }
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
 }

--- a/apps/gateway/test/graphql.test.ts
+++ b/apps/gateway/test/graphql.test.ts
@@ -152,7 +152,7 @@ describe("GraphQL API Integration", () => {
             expect(found.node.variants[0].width).toBe(1920);
         });
 
-        it("should return variant URLs with MEDIA_SERVICE_URL", async () => {
+        it("should return variant URLs with MEDIA_SERVICE_URL when no public request origin is available", async () => {
             // Environment variable set in the setup
 
             await container.resolve(WallpaperRepository).upsert({
@@ -204,6 +204,107 @@ describe("GraphQL API Integration", () => {
             const variant = result.data.searchWallpapers.edges[0].node.variants[0];
             expect(variant.url).toBe(
                 `${process.env.MEDIA_SERVICE_URL}/wallpapers/wlpr_gql_004?w=2560&h=1440&format=image/webp`,
+            );
+        });
+
+        it("should return variant URLs from the browser request origin", async () => {
+            await container.resolve(WallpaperRepository).upsert({
+                wallpaperId: "wlpr_gql_origin_001",
+                userId: "user_gql_origin_001",
+                variants: [
+                    {
+                        width: 3840,
+                        height: 2160,
+                        aspectRatio: 3840 / 2160,
+                        format: "image/webp",
+                        fileSizeBytes: 900000,
+                        createdAt: new Date().toISOString(),
+                    },
+                ],
+                uploadedAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            });
+
+            const query = `
+				query {
+					searchWallpapers(filter: { userId: "user_gql_origin_001" }) {
+						edges {
+							node {
+								variants {
+									url
+								}
+							}
+						}
+					}
+				}
+			`;
+
+            const response = await tester.getApp().inject({
+                method: "POST",
+                url: "/graphql",
+                headers: {
+                    "content-type": "application/json",
+                    origin: "https://zerotwo.bun-shiner.ts.net",
+                },
+                payload: JSON.stringify({ query }),
+            });
+
+            expect(response.statusCode).toBe(200);
+            const result = JSON.parse(response.body);
+            const variant = result.data.searchWallpapers.edges[0].node.variants[0];
+            expect(variant.url).toBe(
+                "https://zerotwo.bun-shiner.ts.net/media/wallpapers/wlpr_gql_origin_001?w=3840&h=2160&format=image/webp",
+            );
+        });
+
+        it("should return variant URLs from forwarded proxy headers", async () => {
+            await container.resolve(WallpaperRepository).upsert({
+                wallpaperId: "wlpr_gql_forwarded_001",
+                userId: "user_gql_forwarded_001",
+                variants: [
+                    {
+                        width: 1920,
+                        height: 1080,
+                        aspectRatio: 1920 / 1080,
+                        format: "image/jpeg",
+                        fileSizeBytes: 500000,
+                        createdAt: new Date().toISOString(),
+                    },
+                ],
+                uploadedAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+            });
+
+            const query = `
+				query {
+					searchWallpapers(filter: { userId: "user_gql_forwarded_001" }) {
+						edges {
+							node {
+								variants {
+									url
+								}
+							}
+						}
+					}
+				}
+			`;
+
+            const response = await tester.getApp().inject({
+                method: "POST",
+                url: "/graphql",
+                headers: {
+                    "content-type": "application/json",
+                    "x-forwarded-proto": "http",
+                    "x-forwarded-host": "zerotwo:8000",
+                },
+                payload: JSON.stringify({ query }),
+            });
+
+            expect(response.statusCode).toBe(200);
+            const result = JSON.parse(response.body);
+            const variant = result.data.searchWallpapers.edges[0].node.variants[0];
+            expect(variant.url).toBe(
+                "http://zerotwo:8000/media/wallpapers/wlpr_gql_forwarded_001?w=1920&h=1080&format=image/jpeg",
             );
         });
 

--- a/scripts/setup-worktree.mjs
+++ b/scripts/setup-worktree.mjs
@@ -488,6 +488,8 @@ function buildServiceOverrides() {
 			OPENSEARCH_URL: "http://opensearch:9200",
 			MEDIA_SERVICE_URL: (ctx) =>
 				`http://localhost:${ctx.ports.INGRESS_PORT}/media`,
+			MEDIA_PUBLIC_PATH: "/media",
+			MEDIA_PUBLIC_BASE_URL: "",
 		},
 		"apps/user": {
 			DATABASE_URL:


### PR DESCRIPTION
## Summary

- derive GraphQL media variant URLs from the incoming browser/proxy origin
- add optional `MEDIA_PUBLIC_BASE_URL` and `MEDIA_PUBLIC_PATH` config for explicit public media URL control
- document/generated-env defaults for the public media path
- add GraphQL coverage for origin-based and forwarded-header-based URL generation

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @wallpaperdb/gateway exec biome format --write src/config.ts src/graphql/resolvers.ts test/graphql.test.ts .env.example ../../scripts/setup-worktree.mjs`
- `pnpm --filter @wallpaperdb/gateway check-types`
- `pnpm --filter @wallpaperdb/gateway build`
- Live stack verification before isolating this PR branch:
  - `Origin: https://zerotwo.bun-shiner.ts.net` returned `https://zerotwo.bun-shiner.ts.net/media/...`
  - `Origin: http://zerotwo:8000` returned `http://zerotwo:8000/media/...`
  - Tailscale media URL returned HTTP 200

## Notes

A narrow Vitest invocation for `test/graphql.test.ts` could not run in this temporary PR worktree because Testcontainers could not find a working container runtime strategy from that path. The same behavior was not used as pass/fail evidence for this PR; typecheck, build, and live running-stack verification passed.
