### PR TITLE
chore(infra): add AppArmor-unconfined compose overrides

### DIFF
--- a/infra/docker-compose.apparmor-unconfined.yml
+++ b/infra/docker-compose.apparmor-unconfined.yml
@@ -1,0 +1,36 @@
+services:
+  postgres:
+    security_opt:
+      - apparmor=unconfined
+  minio:
+    security_opt:
+      - apparmor=unconfined
+  minio-init:
+    security_opt:
+      - apparmor=unconfined
+  opensearch:
+    security_opt:
+      - apparmor=unconfined
+  opensearch-dashboards:
+    security_opt:
+      - apparmor=unconfined
+  nats:
+    security_opt:
+      - apparmor=unconfined
+  nats-setup:
+    security_opt:
+      - apparmor=unconfined
+  pgadmin:
+    security_opt:
+      - apparmor=unconfined
+  redis:
+    security_opt:
+      - apparmor=unconfined
+  lgtm:
+    security_opt:
+      - apparmor=unconfined
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/infra/docker-compose.apps.apparmor-unconfined.yml
+++ b/infra/docker-compose.apps.apparmor-unconfined.yml
@@ -1,0 +1,28 @@
+services:
+  ingestor:
+    security_opt:
+      - apparmor=unconfined
+  media:
+    security_opt:
+      - apparmor=unconfined
+  gateway:
+    security_opt:
+      - apparmor=unconfined
+  variant-generator:
+    security_opt:
+      - apparmor=unconfined
+  color-extractor:
+    security_opt:
+      - apparmor=unconfined
+  tags:
+    security_opt:
+      - apparmor=unconfined
+  user:
+    security_opt:
+      - apparmor=unconfined
+  web:
+    security_opt:
+      - apparmor=unconfined
+  caddy:
+    security_opt:
+      - apparmor=unconfined


### PR DESCRIPTION
## Summary
- add optional compose override for base infra services with `apparmor=unconfined`
- add optional compose override for app services with `apparmor=unconfined`
- override LGTM healthcheck to use curl for the existing image environment

## Tests
- docker compose -f /home/rafaeltab/wallpaperdb/infra/docker-compose.yml -f /home/rafaeltab/wallpaperdb/infra/docker-compose.apparmor-unconfined.yml config
- docker compose -f /home/rafaeltab/wallpaperdb/infra/docker-compose.yml -f /home/rafaeltab/wallpaperdb/infra/docker-compose.apps.yml -f /home/rafaeltab/wallpaperdb/infra/docker-compose.apps.apparmor-unconfined.yml config