### PR TITLE
chore(sandcastle): switch default model to GPT-5.6 Sol

### DIFF
--- a/.sandcastle/config.ts
+++ b/.sandcastle/config.ts
@@ -18,7 +18,7 @@ export function loadConfig(): SandcastleConfig {
 
   return {
     maxIterations: Number(process.env.SANDCASTLE_MAX_ITERATIONS ?? "10"),
-    model: process.env.SANDCASTLE_OPENCODE_MODEL ?? "openai/gpt-5.6",
+    model: process.env.SANDCASTLE_OPENCODE_MODEL ?? "openai/gpt-5.6-sol",
     modelVariant: process.env.SANDCASTLE_OPENCODE_VARIANT ?? "medium",
     imageName: process.env.SANDCASTLE_IMAGE_NAME ?? "wallpaperdb-sandcastle:opencode",
     prBaseBranch: process.env.SANDCASTLE_PR_BASE_BRANCH,


### PR DESCRIPTION
## Summary

- change Sandcastle's default OpenCode model from `openai/gpt-5.6` to `openai/gpt-5.6-sol`
- preserve `SANDCASTLE_OPENCODE_MODEL` as an environment override

## Verification

- `pnpm exec tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --skipLibCheck .sandcastle/main.ts`
- `SANDCASTLE_MAX_ITERATIONS=0 pnpm run sandcastle`
- `git diff --check origin/main...HEAD`
