### PR TITLE
chore(sandcastle): share Turborepo cache across sandboxes

### DIFF
--- a/.sandcastle/helpers.test.ts
+++ b/.sandcastle/helpers.test.ts
@@ -1,7 +1,13 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { getDockerProjectName } from "./docker-resources.js";
 import { parsePlan } from "./plan.js";
+import { prepareTurboCacheDirectory } from "./sandbox.js";
 
 describe("parsePlan", () => {
   it("accepts a valid deterministic issue plan", () => {
@@ -23,5 +29,49 @@ describe("getDockerProjectName", () => {
     const name = getDockerProjectName("sandcastle/Issue_42!" + "x".repeat(100));
     expect(name).toMatch(/^wallpaperdb-[a-z0-9-]+$/);
     expect(name.length).toBeLessThanOrEqual(63);
+  });
+});
+
+describe("prepareTurboCacheDirectory", () => {
+  it("pre-creates one cache shared by linked worktrees", () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), "wallpaperdb-turbo-cache-"));
+    const repository = join(fixtureDir, "repository");
+    const worktree = join(fixtureDir, "worktree");
+
+    try {
+      execFileSync("git", ["init", "--quiet", repository]);
+      execFileSync("git", [
+        "-C",
+        repository,
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "--allow-empty",
+        "--quiet",
+        "-m",
+        "initial",
+      ]);
+      execFileSync("git", [
+        "-C",
+        repository,
+        "worktree",
+        "add",
+        "--quiet",
+        "-b",
+        "cache-test",
+        worktree,
+      ]);
+
+      const repositoryCache = prepareTurboCacheDirectory(repository);
+      const worktreeCache = prepareTurboCacheDirectory(worktree);
+
+      expect(worktreeCache).toBe(repositoryCache);
+      expect(repositoryCache).toBe(join(repository, ".git", "sandcastle", "turbo-cache"));
+      expect(existsSync(repositoryCache)).toBe(true);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
   });
 });

--- a/.sandcastle/sandbox.ts
+++ b/.sandcastle/sandbox.ts
@@ -1,13 +1,17 @@
 import { execFileSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
 
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 
 import type { SandcastleConfig } from "./config.js";
 
 export function createSandboxResources(config: SandcastleConfig) {
+  const turboCacheHostPath = prepareTurboCacheDirectory();
   const env: Record<string, string> = {
     CI: "true",
     DOCKER_HOST: "unix:///var/run/docker.sock",
+    TURBO_CACHE_DIR: "/home/agent/.cache/wallpaperdb-turbo",
   };
   if (process.env.GH_TOKEN) env.GH_TOKEN = process.env.GH_TOKEN;
 
@@ -18,6 +22,11 @@ export function createSandboxResources(config: SandcastleConfig) {
     groups: [getDockerGroupId()],
     mounts: [
       { hostPath: "/var/run/docker.sock", sandboxPath: "/var/run/docker.sock", readonly: false },
+      {
+        hostPath: turboCacheHostPath,
+        sandboxPath: env.TURBO_CACHE_DIR,
+        readonly: false,
+      },
       {
         hostPath: "./.sandcastle/.opencode/auth.json",
         sandboxPath: "/home/agent/.local/share/opencode/auth.json",
@@ -44,6 +53,19 @@ export function createSandboxResources(config: SandcastleConfig) {
   };
 
   return { sandboxProvider, hooks };
+}
+
+export function prepareTurboCacheDirectory(cwd = process.cwd()): string {
+  // The common Git directory is shared by every linked worktree, so planner,
+  // implementer, and reviewer sandboxes all reuse one project-local cache.
+  const gitCommonDir = execFileSync("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  const cacheDir = resolve(gitCommonDir, "sandcastle", "turbo-cache");
+  mkdirSync(cacheDir, { recursive: true });
+  return cacheDir;
 }
 
 function getDockerGroupId(): number {


### PR DESCRIPTION
## Problem

Every Docker-backed Sandcastle sandbox currently writes Turborepo artifacts to its own worktree-local `.turbo` directory, so planner, implementer, and reviewer runs cannot reuse completed task outputs.

## Solution

- create a project-local cache under the repository's shared Git common directory
- bind-mount that directory read/write into every Sandcastle container
- point Turborepo at the mounted directory with the supported `TURBO_CACHE_DIR` environment variable
- resolve the Git common directory rather than the current worktree so linked worktrees all use the same cache
- test that the cache path is pre-created and identical from a repository and linked worktree

## Verification

- `pnpm vitest run .sandcastle/helpers.test.ts`
- targeted TypeScript compilation for the changed Sandcastle files
- `SANDCASTLE_MAX_ITERATIONS=0 pnpm sandcastle`
- `make check` (51 tasks passed)
- two fresh Docker containers using the mounted directory: first run cache miss, second run cache hit with `FULL TURBO`, and the output artifact was restored
